### PR TITLE
Yang model modifications

### DIFF
--- a/src/sonic-yang-mgmt/tests/yang-model-tests/yangModelTesting.py
+++ b/src/sonic-yang-mgmt/tests/yang-model-tests/yangModelTesting.py
@@ -153,7 +153,7 @@ class YangModelTesting:
             for test in self.tests:
                 test = test.strip()
                 if test in self.ExceptionTests:
-                    self.runExceptionTest(test);
+                    ret = ret + self.runExceptionTest(test);
         except Exception as e:
             printExceptionDetails()
             raise e

--- a/src/sonic-yang-mgmt/tests/yang-model-tests/yangTest.json
+++ b/src/sonic-yang-mgmt/tests/yang-model-tests/yangTest.json
@@ -3,7 +3,7 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_INTERFACE": {
 				"VLAN_INTERFACE_LIST": [{
-					"vlanid": 100,
+					"vlan_name": "Vlan100",
 					"ip-prefix": "2a04:5555:66:7777::1/64",
 					"scope": "global",
 					"family": "IPv4"
@@ -11,7 +11,7 @@
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlanid": 100,
+					"vlan_name": "Vlan100",
 					"description": "server_vlan"
 				}]
 			}
@@ -22,7 +22,7 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlanid": 100,
+					"vlan_name": "Vlan100",
 					"description": "server_vlan",
 					"dhcp_servers": [
 						"10.186.72.566"
@@ -34,18 +34,18 @@
 		}
 	},
 
-	"VLAN_HAS_NON_EXIST_PORT": {
+	"VLAN_WITH_NON_EXIST_PORT": {
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_MEMBER": {
 				"VLAN_MEMBER_LIST": [{
-					"vlanid": 100,
+					"vlan_name": "Vlan100",
 					"port": "Ethernet156",
 					"tagging_mode": "tagged"
 				}]
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlanid": 100,
+					"vlan_name": "Vlan100",
 					"description": "server_vlan"
 				}]
 			}
@@ -77,18 +77,18 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_MEMBER": {
 				"VLAN_MEMBER_LIST": [{
-					"vlanid": 200,
+					"vlan_name": "Vlan200",
 					"port": "Ethernet0",
 					"tagging_mode": "tagged"
 				}]
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-						"vlanid": 100,
+						"vlan_name": "Vlan100",
 						"description": "server_vlan"
 					},
 					{
-						"vlanid": 300,
+						"vlan_name": "Vlan300",
 						"description": "ipmi_vlan"
 					}
 				]
@@ -112,14 +112,14 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_MEMBER": {
 				"VLAN_MEMBER_LIST": [{
-					"vlanid": 100,
+					"vlan_name": 100,
 					"port": "Ethernet0",
 					"tagging_mode": "non-tagged"
 				}]
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlanid": 100,
+					"vlan_name": "Vlan100",
 					"description": "server_vlan"
 				}]
 			}

--- a/src/sonic-yang-mgmt/yang-models/sonic-acl.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-acl.yang
@@ -77,7 +77,7 @@ module sonic-acl {
 				choice ip_prefix {
 
 					case ip4_prefix {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='IPV4ANY' or .='ARP'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='ARP'])";
 						leaf SRC_IP {
 							type inet:ipv4-prefix;
 						}
@@ -88,7 +88,7 @@ module sonic-acl {
 					}
 
 					case ip6_prefix {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY' or .='IPV6ANY'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])";
 						leaf SRC_IPV6 {
 							type inet:ipv6-prefix;
 						}
@@ -170,7 +170,7 @@ module sonic-acl {
 				choice icmp {
 
 					case icmp4 {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='IPV4ANY' or .='ARP'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='ARP'])";
 						leaf ICMP_TYPE {
 							type uint8 {
 								range 1..44;
@@ -185,7 +185,7 @@ module sonic-acl {
 					}
 
 					case icmp6 {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY' or .='IPV6ANY'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])";
 						leaf ICMPV6_TYPE {
 							type uint8 {
 								range 1..44;

--- a/src/sonic-yang-mgmt/yang-models/sonic-acl.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-acl.yang
@@ -77,7 +77,7 @@ module sonic-acl {
 				choice ip_prefix {
 
 					case ip4_prefix {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPV4ANY' or .='ARP'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='IPV4ANY' or .='ARP'])";
 						leaf SRC_IP {
 							type inet:ipv4-prefix;
 						}
@@ -88,7 +88,7 @@ module sonic-acl {
 					}
 
 					case ip6_prefix {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPV6ANY'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY' or .='IPV6ANY'])";
 						leaf SRC_IPV6 {
 							type inet:ipv6-prefix;
 						}
@@ -170,7 +170,7 @@ module sonic-acl {
 				choice icmp {
 
 					case icmp4 {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPV4ANY' or .='ARP'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='IPV4ANY' or .='ARP'])";
 						leaf ICMP_TYPE {
 							type uint8 {
 								range 1..44;
@@ -185,7 +185,7 @@ module sonic-acl {
 					}
 
 					case icmp6 {
-						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPV6ANY'])";
+						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY' or .='IPV6ANY'])";
 						leaf ICMPV6_TYPE {
 							type uint8 {
 								range 1..44;

--- a/src/sonic-yang-mgmt/yang-models/sonic-head.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-head.yang
@@ -43,9 +43,9 @@ module sonic-head {
             enum IPV4;
             enum IPV6;
             enum IPv4ANY;
-            enum NON_IPV4;
+            enum NON_IP4;
             enum IPv6ANY;
-            enum NON_IPV6;
+            enum NON_IPv6;
             enum ARP;
         }
     }

--- a/src/sonic-yang-mgmt/yang-models/sonic-head.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-head.yang
@@ -43,11 +43,9 @@ module sonic-head {
             enum IPV4;
             enum IPV6;
             enum IPv4ANY;
-            enum IPV4ANY;
-            enum NON_IPv4;
+            enum NON_IPV4;
             enum IPv6ANY;
-            enum IPV6ANY;
-            enum NON_IPv6;
+            enum NON_IPV6;
             enum ARP;
         }
     }

--- a/src/sonic-yang-mgmt/yang-models/sonic-head.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-head.yang
@@ -42,8 +42,10 @@ module sonic-head {
             enum NON_IP;
             enum IPV4;
             enum IPV6;
+            enum IPv4ANY;
             enum IPV4ANY;
             enum NON_IPv4;
+            enum IPv6ANY;
             enum IPV6ANY;
             enum NON_IPv6;
             enum ARP;

--- a/src/sonic-yang-mgmt/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-interface.yang
@@ -47,6 +47,7 @@ module sonic-interface {
 				}
 
 				leaf ip-prefix {
+                    /* TODO: this should be custom, not inet:ip-prefix.*/
 					type inet:ip-prefix;
 				}
 

--- a/src/sonic-yang-mgmt/yang-models/sonic-port.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-port.yang
@@ -55,7 +55,7 @@ module sonic-port{
 
 				leaf description {
 					type string {
-						length 1..255;
+						length 0..255;
 					}
 				}
 
@@ -74,6 +74,12 @@ module sonic-port{
 				leaf admin_status {
 					mandatory true;
 					type head:admin_status;
+				}
+
+				leaf fec {
+					type string {
+						pattern "rc|fc|None";
+					}
 				}
 			} /* end of list PORT_LIST */
 

--- a/src/sonic-yang-mgmt/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-vlan.yang
@@ -38,11 +38,11 @@ module sonic-vlan {
 
 			list VLAN_INTERFACE_LIST {
 
-				key "vlanid ip-prefix";
+				key "vlan_name ip-prefix";
 
-				leaf vlanid {
+				leaf vlan_name {
 					type leafref {
-						path ../../../VLAN/VLAN_LIST/vlanid;
+						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:vlan_name";
 					}
 				}
 
@@ -81,7 +81,13 @@ module sonic-vlan {
 
 			list VLAN_LIST {
 
-				key "vlanid";
+				key "vlan_name";
+
+				leaf vlan_name {
+					type string {
+						pattern 'Vlan([0-9]{1,3}|[0-3][0-9]{4}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+					}
+				}
 
 				leaf vlanid {
 					type uint16 {
@@ -114,7 +120,7 @@ module sonic-vlan {
 					/* leaf-list members are unique by default */
 
 					type leafref {
-						path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+						path "/port:sonic-port/port:PORT/port:PORT_LIST/port:port_name";
 					}
 				}
 			}
@@ -128,11 +134,11 @@ module sonic-vlan {
 
 			list VLAN_MEMBER_LIST {
 
-				key "vlanid port";
+				key "vlan_name port";
 
-				leaf vlanid {
+				leaf vlan_name {
 					type leafref {
-						path ../../../VLAN/VLAN_LIST/vlanid;
+						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:vlan_name";
 					}
 				}
 


### PR DESCRIPTION
**- What I did**

    [sonic-head.yang]: Minor modification for enumeration of ip-type in ACL yang models.

    [sonic-vlan.yang]: modify vlan table key from vlanid(int) to vlan_name(string).

    [yangModelTesting.py] Fix Test Code and JSON input.

**- How I did it**
Minor modification for enumeration of ip-type in ACL yang models.
modify vlan table key from vlanid(int) to vlan_name(string).
Fix Test Code and JSON input.

Note: I need to block Current PLY Tests because they do not pass with new YANG Models.

**- How to verify it**
```
INFO:YANG-TEST:
------------------- Test 11: Configure undefined acl_table_type in ACL_TABLE table.---------------------
libyang[0]: Invalid value "LAYER3V4" in "type" element. (path: /sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6']/type)
INFO:YANG-TEST:Configure undefined acl_table_type in ACL_TABLE table. Passed

INFO:YANG-TEST:
------------------- Test 12: Configure undefined packet_action in ACL_RULE table.---------------------
libyang[0]: Invalid value "SEND" in "PACKET_ACTION" element. (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST/PACKET_ACTION)
INFO:YANG-TEST:Configure undefined packet_action in ACL_RULE table. Passed

INFO:YANG-TEST:
------------------- Test 13: Configure wrong value for tagging_mode.---------------------
libyang[0]: Invalid value "non-tagged" in "tagging_mode" element. (path: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST/tagging_mode)
INFO:YANG-TEST:Configure wrong value for tagging_mode. Passed

INFO:YANG-TEST:
------------------- Test 14: Configure vlan-id in VLAN_MEMBER table which does not exist in VLAN  table.---------------------
libyang[0]: Leafref "/sonic-vlan:sonic-vlan/sonic-vlan:VLAN/sonic-vlan:VLAN_LIST/sonic-vlan:vlan_name" of value "Vlan200" points to a non-existing leaf. (path: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan200'][port='Ethernet0']/vlan_name)
libyang[0]: Leafref "/sonic-vlan:sonic-vlan/sonic-vlan:VLAN/sonic-vlan:VLAN_LIST/sonic-vlan:vlan_name" of value "Vlan200" points to a non-existing leaf. (path: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan200'][port='Ethernet0']/vlan_name)
INFO:YANG-TEST:Configure vlan-id in VLAN_MEMBER table which does not exist in VLAN  table. Passed

INFO:YANG-TEST:All Test Passed
../../target/debs/stretch/libyang_1.0.73_amd64.deb installed
../../target/debs/stretch/libyang-cpp_1.0.73_amd64.deb installed
../../target/debs/stretch/python2-yang_1.0.73_amd64.deb installed
YANG Tests passed
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
