### PR TITLE
[test] Adding platform.json configuration file test

### DIFF
--- a/src/sonic-device-data/src/Makefile
+++ b/src/sonic-device-data/src/Makefile
@@ -11,4 +11,7 @@ test:
 	for f in $$(find ../../../device -name media_settings.json); do
 	    ./media_checker $$f
 	done
+	for f in $$(find ../../../device -name platform.json); do
+	    ./platformJson_checker $$f
+	done
 	popd

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -138,7 +138,7 @@ def main(argv):
 
     # Load target file
     if len(argv) == 0:
-        files = glob.glob('*.json')
+        files = glob.glob('*media_settings.json')
     else:
         files = argv
 

--- a/src/sonic-device-data/tests/platformJson_checker
+++ b/src/sonic-device-data/tests/platformJson_checker
@@ -14,6 +14,8 @@ except NameError:
 # Global variable
 PORT_ATTRIBUTES = ["index", "lanes", "alias_at_lanes", "breakout_modes", "default_brkout_mode"]
 ATTR_LEN = len(PORT_ATTRIBUTES)
+PORT_REG = "Ethernet(\d+)"
+PLATFORM_JSON = '*platform.json'
 
 def usage():
     print "Usage: " + sys.argv[0] + " <platform_json_file>"
@@ -42,7 +44,7 @@ def check_file(platform_json_file):
         for each_port in port_dict:
 
             # Validate port at top level
-            port_id = re.search("Ethernet(\d+)", each_port)
+            port_id = re.search(PORT_REG, each_port)
             if port_id is  None:
                 print "Error: Unknown Interface " + str(each_port) + " at top level"
                 return False
@@ -77,7 +79,7 @@ def main(argv):
 
     # Load target file
     if len(argv) == 0:
-        files = glob.glob('*platform.json')
+        files = glob.glob(PLATFORM_JSON)
     else:
         files = argv
 

--- a/src/sonic-device-data/tests/platformJson_checker
+++ b/src/sonic-device-data/tests/platformJson_checker
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+try:
+    import re
+    import sys
+    import glob
+    import json
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+try:
+  basestring
+except NameError:
+  basestring = str
+
+# Global variable
+PORT_ATTRIBUTES = ["index", "lanes", "alias_at_lanes", "breakout_modes", "default_brkout_mode"]
+ATTR_LEN = len(PORT_ATTRIBUTES)
+
+def usage():
+    print "Usage: " + sys.argv[0] + " <platform_json_file>"
+    sys.exit(1)
+
+
+def check_port_attr(port_attr):
+    for each_key in port_attr:
+        if each_key not in PORT_ATTRIBUTES:
+            print "Error: "+ each_key + " is not the correct Port attribute."
+            return False
+        if not port_attr[each_key]:
+            print "Error: "+ each_key + " has no value."
+            return False
+        if not isinstance(port_attr[each_key], basestring):
+            print "Error:value type of  "+ each_key + " must be string."
+            return False
+    return True
+
+def check_file(platform_json_file):
+    try:
+        platform_cap_file = open(platform_json_file,"r")
+        platform_file_data = platform_cap_file.read()
+        port_dict = json.loads(platform_file_data)
+
+        for each_port in port_dict:
+
+            # Validate port at top level
+            port_id = re.search("Ethernet(\d+)", each_port)
+            if port_id is  None:
+                print "Error: Unknown Interface " + str(each_port) + " at top level"
+                return False
+
+            total_attr = len(port_dict[each_port].keys())
+            port_attr = port_dict[each_port]
+
+            if total_attr != ATTR_LEN:
+                missing_attr = ', '.join(set(PORT_ATTRIBUTES).difference(list(port_attr)))
+                print "Error: " + missing_attr + " of " + each_port + " is/are missing"
+                return False
+
+            #Validate port attributes for each port
+            if not check_port_attr(port_attr):
+                return False
+
+    except IOError:
+        print "Error: Cannot open file " + platform_json_file
+        return False
+    except ValueError,e:
+        print "Error in parsing json file " + platform_json_file + " "
+        print str(e)
+        return False
+
+    return True
+
+
+def main(argv):
+
+    if len(argv) > 0 and argv[0] == "-h":
+        usage()
+
+    # Load target file
+    if len(argv) == 0:
+        files = glob.glob('*platform.json')
+    else:
+        files = argv
+
+    all_good = True
+
+    for f in files:
+        good = check_file(f)
+        if good:
+            print "File " + f + " passed validity check"
+        else:
+            print "File " + f + " failed validity check"
+
+        all_good = all_good and good
+
+    if not all_good:
+        sys.exit(-1)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION

**- What I did**
In order to allow the SONiC community to check in platform capability file i.e. **platform.json**
file directly under device folder. We need to add this test to make sure the contents of the this file is compliant with platform capability design specified in [DPB HLD doc](https://github.com/zhenggen-xu/SONiC/blob/DPB-design/doc/dynamic-port-breakout/sonic-dynamic-port-breakout-HLD.md)

**- How I did it**
Added **platformJson_checker.py** file in Test folder. 

**- How to verify it**
With the change as-is, build passes, the built image executed on the target platform, the configuration was applied properly.

> Snapshot of success Build

```
samaity@43b85cf2e5e7:/sonic$ BLDENV=stretch make -f slave.mk target/debs/stretch/sonic-device-data_1.0-1_all.deb
SONiC Build System
 
Build Configuration
"CONFIGURED_PLATFORM"             : "vs"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "admin123"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : "y"
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"
 
samaity@43b85cf2e5e7:/sonic$ ls -la target/debs/stretch/sonic-device-data_1.0-1_all.deb*
-rw-r--r-- 1 samaity gsamaity 5806088 Dec  4 01:29 target/debs/stretch/sonic-device-data_1.0-1_all.deb
-rw-r--r-- 1 samaity gsamaity   27553 Dec  4 01:29 target/debs/stretch/sonic-device-data_1.0-1_all.deb.log
```
 
> Snapshot of target/debs/stretch/sonic-device-data_1.0-1_all.deb.log
```
File ../../../device/dell/x86_64-dellemc_z9264f_c3538-r0/media_settings.json passed validity check
File ../../../device/celestica/x86_64-cel_seastone-r0/platform.json passed validity check
/sonic/src/sonic-device-data/src
 
```

Created a few bad platform.json files to test. Build got failed for all the bad platform capability file.
**Build hit following failure:**

> index value is missing 

```
Error: index of Ethernet0 has no value.
File ../../../device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-25-50/platform.json failed validity check
Makefile:6: recipe for target 'test' failed
make[3]: *** [test] Error 255
make[3]: Leaving directory '/sonic/src/sonic-device-data/src'
```
> interface name is wrong in this case.
```
Error: Unknown Interface Esthernet8s at top level
File ../../../device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/platform.json failed validity check
Makefile:6: recipe for target 'test' failed
make[3]: *** [test] Error 255
make[3]: Leaving directory '/sonic/src/sonic-device-data/src'
```
> brakout_modes is not the correct port attribute. syntax Error
```
File ../../../device/dell/x86_64-dellemc_z9264f_c3538-r0/media_settings.json passed validity check
Error: brakout_modes is not the correct Port attribute.
File ../../../device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50-40/platform.json failed validity check
Makefile:6: recipe for target 'test' failed
make[3]: *** [test] Error 255
```
> some of the port Attribute is missing

```
File ../../../device/celestica/x86_64-cel_seastone-r0/platform.json passed validity check
Error: index, default_brkout_mode of Ethernet16 is/are missing
File ../../../device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/platform.json failed validity check
Makefile:6: recipe for target 'test' failed
make[3]: *** [test] Error 255
```

