### PR TITLE
Refractored portconfig to be used by breakout CLI subcommand

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -17,7 +17,7 @@ SONIC_ROOT_PATH = '/usr/share/sonic'
 HWSKU_ROOT_PATH = '/usr/share/sonic/hwsku'
 
 PLATFORM_JSON = 'platform.json'
-PORT_CONFIG_INI = 'portconfig.ini'
+PORT_CONFIG_INI = 'port_config.ini'
 
 PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
@@ -33,8 +33,7 @@ def db_connect_configdb():
         return None
     try:
         config_db.connect()
-    except Exception as e:
-        print("Config DB is not available with error {}".format(str(e)))
+    except:
         config_db = None
     return config_db
 
@@ -204,10 +203,17 @@ def parse_platform_json_file(port_config_file, interface_name=None, target_brkou
         if match_list is not None:
             offset = 0
             parent_intf_id = int(re.search("Ethernet(\d+)", intf).group(1))
+
+            if interface_name is not None and interface_name == intf:
+                ports = {}
+
             for k in match_list:
                 # k is a tuple in "match_list"
                 offset = gen_port_config(ports, parent_intf_id, index, alias_at_lanes, lanes, k, offset)
             brkout_mode = None
+
+            if interface_name is not None and interface_name == intf:
+                return ports
         else:
             raise Exception("match_list should not be None.")
     if not ports:


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
Passing interface name variable to use the same function in breakout mode CLI subcommand. 

**- How to verify it**

rebuilt "sonic_config_engine-1.0" wheel package with all the test cases passing successfully. All the below-mentioned test cases passed.
```
# Check whether all interfaces present or not as per platform.json
def test_platform_json_interfaces_keys(self):
       
# Check specific Interface with it's proper configuration as per platform.json
def test_platform_json_specific_ethernet_interfaces(self):

# Check all Interface with it's proper configuration as per platform.json
def test_platform_json_all_ethernet_interfaces(self):
```
Log File
```
samaity@a6cad4e9d072:/sonic$ BLDENV=stretch make -f slave.mk target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "vs"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "admin123"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : "y"
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"
```

```
root@cc6a0176b0b8:/# sonic-cfggen -p /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/platform.json -k Force10-S6000 --print-data
{
    "DEVICE_METADATA": {
        "localhost": {
            "hwsku": "Force10-S6000"
        }
    },
    "PORT": {
        "Ethernet0": {
            "admin_status": "up",
            "alias": "Eth1/1",
            "index": "1",
            "lanes": "65,66,67,68",
            "speed": "100G"
        },
        "Ethernet4": {
            "admin_status": "up",
            "alias": "Eth2/1",
            "index": "2",
            "lanes": "69,70",
            "speed": "50G"
        },
        "Ethernet6": {
            "admin_status": "up",
            "alias": " Eth2/3",
            "index": "2",
            "lanes": "71,72",
            "speed": "50G"
        },
        "Ethernet8": {
            "admin_status": "up",
            "alias": "Eth3/1",
            "index": "3",
            "lanes": "73",
            "speed": "25G"
        },
        "Ethernet9": {
            "admin_status": "up",
            "alias": " Eth3/2",
            "index": "3",
            "lanes": "74",
            "speed": "25G"
        },
        "Ethernet10": {
            "admin_status": "up",
            "alias": " Eth3/3",
            "index": "3",
            "lanes": "75",
            "speed": "25G"
        },
        "Ethernet11": {
            "admin_status": "up",
            "alias": " Eth3/4",
            "index": "3",
            "lanes": "76",
            "speed": "25G"
        },
        "Ethernet12": {
            "admin_status": "up",
            "alias": "Eth4/1",
            "index": "4",
            "lanes": "77",
            "speed": "25G"
        },
        "Ethernet13": {
            "admin_status": "up",
            "alias": " Eth4/2",
            "index": "4",
            "lanes": "78",
            "speed": "25G"
        },
        "Ethernet14": {
            "admin_status": "up",
            "alias": " Eth4/3",
            "index": "4",
            "lanes": "79,80",
            "speed": "50G"
        },
        "Ethernet16": {
            "admin_status": "up",
            "alias": "Eth5/1",
            "index": "5",
            "lanes": "33,34",
            "speed": "50G"
        },
        "Ethernet18": {
            "admin_status": "up",
            "alias": " Eth5/3",
            "index": "5",
            "lanes": "35",
            "speed": "25G"
        },
        "Ethernet19": {
            "admin_status": "up",
            "alias": " Eth5/4",
            "index": "5",
            "lanes": "36",
            "speed": "25G"
        },
        "Ethernet20": {
            "admin_status": "up",
            "alias": "Eth6/1",
            "index": "6",
            "lanes": "37,38,39,40",
            "speed": "100G"
        },
        "Ethernet24": {
            "admin_status": "up",
            "alias": "Eth7/1",
            "index": "7",
            "lanes": "41,42",
            "speed": "50G"
        },
        "Ethernet26": {
            "admin_status": "up",
            "alias": " Eth7/3",
            "index": "7",
            "lanes": "43,44",
            "speed": "50G"
        },
        "Ethernet28": {
            "admin_status": "up",
            "alias": "Eth8/1",
            "index": "8",
            "lanes": "45",
            "speed": "25G"
        },
        "Ethernet29": {
            "admin_status": "up",
            "alias": " Eth8/2",
            "index": "8",
            "lanes": "46",
            "speed": "25G"
        },
        "Ethernet30": {
            "admin_status": "up",
            "alias": " Eth8/3",
            "index": "8",
            "lanes": "47",
            "speed": "25G"
        },
        "Ethernet31": {
            "admin_status": "up",
            "alias": " Eth8/4",
            "index": "8",
            "lanes": "48",
            "speed": "25G"
        },
        "Ethernet32": {
            "admin_status": "up",
            "alias": "Eth9/1",
            "index": "9",
            "lanes": "49",
            "speed": "25G"
        },
        "Ethernet33": {
            "admin_status": "up",
            "alias": " Eth9/2",
            "index": "9",
            "lanes": "50",
            "speed": "25G"
        },
        "Ethernet34": {
            "admin_status": "up",
            "alias": " Eth9/3",
            "index": "9",
            "lanes": "51,52",
            "speed": "50G"
        },
        "Ethernet36": {
            "admin_status": "up",
            "alias": "Eth10/1",
            "index": "10",
            "lanes": "53,54",
            "speed": "50G"
        },
        "Ethernet38": {
            "admin_status": "up",
            "alias": " Eth10/3",
            "index": "10",
            "lanes": "55",
            "speed": "25G"
        },
        "Ethernet39": {
            "admin_status": "up",
            "alias": " Eth10/4",
            "index": "10",
            "lanes": "56",
            "speed": "25G"
        },
        "Ethernet40": {
            "admin_status": "up",
            "alias": "Eth11/1",
            "index": "11",
            "lanes": "57,58,59,60",
            "speed": "100G"
        },
        "Ethernet44": {
            "admin_status": "up",
            "alias": "Eth12/1",
            "index": "12",
            "lanes": "61,62",
            "speed": "50G"
        },
        "Ethernet46": {
            "admin_status": "up",
            "alias": " Eth12/3",
            "index": "12",
            "lanes": "63,64",
            "speed": "50G"
        },
        "Ethernet48": {
            "admin_status": "up",
            "alias": "Eth13/1",
            "index": "13",
            "lanes": "81",
            "speed": "25G"
        },
        "Ethernet49": {
            "admin_status": "up",
            "alias": " Eth13/2",
            "index": "13",
            "lanes": "82",
            "speed": "25G"
        },
        "Ethernet50": {
            "admin_status": "up",
            "alias": " Eth13/3",
            "index": "13",
            "lanes": "83",
            "speed": "25G"
        },
        "Ethernet51": {
            "admin_status": "up",
            "alias": " Eth13/4",
            "index": "13",
            "lanes": "84",
            "speed": "25G"
        },
        "Ethernet52": {
            "admin_status": "up",
            "alias": "Eth14/1",
            "index": "14",
            "lanes": "85",
            "speed": "25G"
        },
        "Ethernet53": {
            "admin_status": "up",
            "alias": " Eth14/2",
            "index": "14",
            "lanes": "86",
            "speed": "25G"
        },
        "Ethernet54": {
            "admin_status": "up",
            "alias": " Eth14/3",
            "index": "14",
            "lanes": "87,88",
            "speed": "50G"
        },
        "Ethernet56": {
            "admin_status": "up",
            "alias": "Eth15/1",
            "index": "15",
            "lanes": "89,90",
            "speed": "50G"
        },
        "Ethernet58": {
            "admin_status": "up",
            "alias": " Eth15/3",
            "index": "15",
            "lanes": "91",
            "speed": "25G"
        },
        "Ethernet59": {
            "admin_status": "up",
            "alias": " Eth15/4",
            "index": "15",
            "lanes": "92",
            "speed": "25G"
        },
        "Ethernet60": {
            "admin_status": "up",
            "alias": "Eth16/1",
            "index": "16",
            "lanes": "93,94,95,96",
            "speed": "100G"
        },
        "Ethernet64": {
            "admin_status": "up",
            "alias": "Eth17/1",
            "index": "17",
            "lanes": "97,98",
            "speed": "50G"
        },
        "Ethernet66": {
            "admin_status": "up",
            "alias": " Eth17/3",
            "index": "17",
            "lanes": "99,100",
            "speed": "50G"
        },
        "Ethernet68": {
            "admin_status": "up",
            "alias": "Eth18/1",
            "index": "18",
            "lanes": "101",
            "speed": "25G"
        },
        "Ethernet69": {
            "admin_status": "up",
            "alias": " Eth18/2",
            "index": "18",
            "lanes": "102",
            "speed": "25G"
        },
        "Ethernet70": {
            "admin_status": "up",
            "alias": " Eth18/3",
            "index": "18",
            "lanes": "103",
            "speed": "25G"
        },
        "Ethernet71": {
            "admin_status": "up",
            "alias": " Eth18/4",
            "index": "18",
            "lanes": "104",
            "speed": "25G"
        },
        "Ethernet72": {
            "admin_status": "up",
            "alias": "Eth19/1",
            "index": "19",
            "lanes": "105",
            "speed": "25G"
        },
        "Ethernet73": {
            "admin_status": "up",
            "alias": " Eth19/2",
            "index": "19",
            "lanes": "106",
            "speed": "25G"
        },
        "Ethernet74": {
            "admin_status": "up",
            "alias": " Eth19/3",
            "index": "19",
            "lanes": "107,108",
            "speed": "50G"
        },
        "Ethernet76": {
            "admin_status": "up",
            "alias": "Eth20/1",
            "index": "20",
            "lanes": "109,110",
            "speed": "50G"
        },
        "Ethernet78": {
            "admin_status": "up",
            "alias": " Eth20/3",
            "index": "20",
            "lanes": "111",
            "speed": "25G"
        },
        "Ethernet79": {
            "admin_status": "up",
            "alias": " Eth20/4",
            "index": "20",
            "lanes": "112",
            "speed": "25G"
        },
        "Ethernet80": {
            "admin_status": "up",
            "alias": "Eth21/1",
            "index": "21",
            "lanes": "1,2,3,4",
            "speed": "100G"
        },
        "Ethernet84": {
            "admin_status": "up",
            "alias": "Eth22/1",
            "index": "22",
            "lanes": "5,6",
            "speed": "50G"
        },
        "Ethernet86": {
            "admin_status": "up",
            "alias": " Eth22/3",
            "index": "22",
            "lanes": "7,8",
            "speed": "50G"
        },
        "Ethernet88": {
            "admin_status": "up",
            "alias": "Eth23/1",
            "index": "23",
            "lanes": "9",
            "speed": "25G"
        },
        "Ethernet89": {
            "admin_status": "up",
            "alias": " Eth23/2",
            "index": "23",
            "lanes": "10",
            "speed": "25G"
        },
        "Ethernet90": {
            "admin_status": "up",
            "alias": " Eth23/3",
            "index": "23",
            "lanes": "11",
            "speed": "25G"
        },
        "Ethernet91": {
            "admin_status": "up",
            "alias": " Eth23/4",
            "index": "23",
            "lanes": "12",
            "speed": "25G"
        },
        "Ethernet92": {
            "admin_status": "up",
            "alias": "Eth24/1",
            "index": "24",
            "lanes": "13",
            "speed": "25G"
        },
        "Ethernet93": {
            "admin_status": "up",
            "alias": " Eth24/2",
            "index": "24",
            "lanes": "14",
            "speed": "25G"
        },
        "Ethernet94": {
            "admin_status": "up",
            "alias": " Eth24/3",
            "index": "24",
            "lanes": "15,16",
            "speed": "50G"
        },
        "Ethernet96": {
            "admin_status": "up",
            "alias": "Eth25/1",
            "index": "25",
            "lanes": "17,18",
            "speed": "50G"
        },
        "Ethernet98": {
            "admin_status": "up",
            "alias": " Eth25/3",
            "index": "25",
            "lanes": "19",
            "speed": "25G"
        },
        "Ethernet99": {
            "admin_status": "up",
            "alias": " Eth25/4",
            "index": "25",
            "lanes": "20",
            "speed": "25G"
        },
        "Ethernet100": {
            "admin_status": "up",
            "alias": "Eth26/1",
            "index": "26",
            "lanes": "21,22,23,24",
            "speed": "100G"
        },
        "Ethernet104": {
            "admin_status": "up",
            "alias": "Eth27/1",
            "index": "27",
            "lanes": "25,26",
            "speed": "50G"
        },
        "Ethernet106": {
            "admin_status": "up",
            "alias": " Eth27/3",
            "index": "27",
            "lanes": "27,28",
            "speed": "50G"
        },
        "Ethernet108": {
            "admin_status": "up",
            "alias": "Eth28/1",
            "index": "28",
            "lanes": "29",
            "speed": "25G"
        },
        "Ethernet109": {
            "admin_status": "up",
            "alias": " Eth28/2",
            "index": "28",
            "lanes": "30",
            "speed": "25G"
        },
        "Ethernet110": {
            "admin_status": "up",
            "alias": " Eth28/3",
            "index": "28",
            "lanes": "31",
            "speed": "25G"
        },
        "Ethernet111": {
            "admin_status": "up",
            "alias": " Eth28/4",
            "index": "28",
            "lanes": "32",
            "speed": "25G"
        },
        "Ethernet112": {
            "admin_status": "up",
            "alias": "Eth29/1",
            "index": "29",
            "lanes": "113",
            "speed": "25G"
        },
        "Ethernet113": {
            "admin_status": "up",
            "alias": " Eth29/2",
            "index": "29",
            "lanes": "114",
            "speed": "25G"
        },
        "Ethernet114": {
            "admin_status": "up",
            "alias": " Eth29/3",
            "index": "29",
            "lanes": "115,116",
            "speed": "50G"
        },
        "Ethernet116": {
            "admin_status": "up",
            "alias": "Eth30/1",
            "index": "30",
            "lanes": "117,118",
            "speed": "50G"
        },
        "Ethernet118": {
            "admin_status": "up",
            "alias": " Eth30/3",
            "index": "30",
            "lanes": "119",
            "speed": "25G"
        },
        "Ethernet119": {
            "admin_status": "up",
            "alias": " Eth30/4",
            "index": "30",
            "lanes": "120",
            "speed": "25G"
        },
        "Ethernet120": {
            "admin_status": "up",
            "alias": "Eth31/1",
            "index": "31",
            "lanes": "121,122,123,124",
            "speed": "100G"
        },
        "Ethernet124": {
            "admin_status": "up",
            "alias": "Eth32/1",
            "index": "32",
            "lanes": "125,126",
            "speed": "50G"
        },
        "Ethernet126": {
            "admin_status": "up",
            "alias": " Eth32/3",
            "index": "32",
            "lanes": "127,128",
            "speed": "50G"
        }
    }
}
```