### PR TITLE
Adding a new function to create BRKOUT_CFG TABLE in config db

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -157,13 +157,18 @@ def gen_port_config(ports, parent_intf_id, index, alias_at_lanes, lanes, k,  off
             ports[intf_name]['alias'] = alias_at_lanes.split(",")[alias_start]
             ports[intf_name]['lanes'] = ','.join(lanes.split(",")[alias_start:alias_start+step])
             if speed:
-		if 'G'  not in speed.upper():
-		    raise Exception('{} speed is not Supported...'.format(speed))
-                num = re.split("G", speed.upper())
-                conv_speed = int(num[0])*1000
+                speed_pat = re.search("^((\d+)G|\d+)$", speed.upper())
+                if speed_pat is None:
+                    raise Exception('{} speed is not Supported...'.format(speed))
+                speed_G, speed_orig = speed_pat.group(2), speed_pat.group(1)
+                if speed_G:
+                    conv_speed = int(speed_G)*1000
+                else:
+                    conv_speed = int(speed_orig)
                 ports[intf_name]['speed'] = str(conv_speed)
             else:
                 raise Exception('Regex return for speed is None...')
+
             ports[intf_name]['index'] = index.split(",")[alias_start]
             ports[intf_name]['admin_status'] = "up"
 

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -21,8 +21,26 @@ PORT_CONFIG_INI = 'port_config.ini'
 
 PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
+CUR_BRKOUT_MODE = "brkout_mode"
 
 BRKOUT_PATTERN = r'(\d{1,3})x(\d{1,3}G)(\[\d{1,3}G\])?(\((\d{1,3})\))?'
+
+#
+# Helper Functions
+#
+def readJson(port_config_file):
+    # Read 'platform.json' file
+    try:
+        with open(port_config_file) as fp:
+            try:
+                data = json.load(fp)
+            except json.JSONDecodeError:
+                print("Json file does not exist")
+        port_dict = ast.literal_eval(json.dumps(data))
+        return port_dict
+    except:
+        print("error occurred while parsing json:", sys.exc_info()[1])
+        return None
 
 def db_connect_configdb():
     """
@@ -157,17 +175,9 @@ def parse_platform_json_file(port_config_file, interface_name=None, target_brkou
     ports = {}
     port_alias_map = {}
 
-    # Read 'platform.json' file
-    try:
-        with open(port_config_file) as fp:
-            try:
-                data = json.load(fp)
-            except json.JSONDecodeError as e:
-                raise Exception("JSONDecodeError:", e)
-        global port_dict
-        port_dict = ast.literal_eval(json.dumps(data))
-    except:
-        print("error occurred while parsing json:", sys.exc_info()[1])
+    port_dict = readJson(port_config_file)
+    if not port_dict:
+        raise Exception("port_dict is none")
 
     for intf in port_dict:
         if str(interface_name) == intf:
@@ -222,3 +232,25 @@ def parse_platform_json_file(port_config_file, interface_name=None, target_brkou
     for i in ports.keys():
         port_alias_map[ports[i]["alias"]]= i
     return (ports, port_alias_map)
+
+
+def get_breakout_mode(hwsku=None, platform=None, port_config_file=None):
+    if not port_config_file:
+        port_config_file = get_port_config_file_name(hwsku, platform)
+        if not port_config_file:
+            return None
+    if port_config_file.endswith('.json'):
+        return parse_breakout_mode(port_config_file)
+    else:
+        return None
+
+def parse_breakout_mode(port_config_file):
+    brkout_table = {}
+    port_dict = readJson(port_config_file)
+    if not port_dict:
+        raise Exception("Port_dict is empty")
+
+    for intf in port_dict:
+        brkout_table[intf] = {}
+        brkout_table[intf][CUR_BRKOUT_MODE] = port_dict[intf][BRKOUT_MODE]
+    return brkout_table

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -88,7 +88,7 @@ def get_port_config(hwsku=None, platform=None, port_config_file=None):
     config_db = db_connect_configdb()
 
     # If available, Read from CONFIG DB first
-    if config_db is not None:
+    if config_db is not None and port_config_file is None:
 
         port_data = config_db.get_table("PORT")
         if port_data is not None:
@@ -157,7 +157,11 @@ def gen_port_config(ports, parent_intf_id, index, alias_at_lanes, lanes, k,  off
             ports[intf_name]['alias'] = alias_at_lanes.split(",")[alias_start]
             ports[intf_name]['lanes'] = ','.join(lanes.split(",")[alias_start:alias_start+step])
             if speed:
-                ports[intf_name]['speed'] = speed
+		if 'G'  not in speed.upper():
+		    raise Exception('{} speed is not Supported...'.format(speed))
+                num = re.split("G", speed.upper())
+                conv_speed = int(num[0])*1000
+                ports[intf_name]['speed'] = str(conv_speed)
             else:
                 raise Exception('Regex return for speed is None...')
             ports[intf_name]['index'] = index.split(",")[alias_start]

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -37,7 +37,7 @@ from functools import partial
 from minigraph import minigraph_encoder
 from minigraph import parse_xml
 from minigraph import parse_device_desc_xml
-from portconfig import get_port_config
+from portconfig import get_port_config, get_breakout_mode
 from sonic_device_util import get_machine_info
 from sonic_device_util import get_platform_info
 from sonic_device_util import get_system_mac
@@ -232,6 +232,10 @@ def main():
             print('Failed to get port config', file=sys.stderr)
             sys.exit(1)
         deep_update(data, {'PORT': ports})
+
+        brkout_table = get_breakout_mode(hwsku, platform, args.port_config)
+        if  brkout_table is not None:
+            deep_update(data, {'BREAKOUT_CFG': brkout_table})
 
     if args.minigraph != None:
         minigraph = args.minigraph


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**
BREAKOUT_CFG Table will be generated in `config db` if platform.json is available.
.
**- How I did it**
Added a new Function `get_breakout_mode` function in `portconfig` file and using this function in `sonic-cfggen`,  `"BREAKOUT_CFG"` get generated.

so, if platform.json is available in the device, `"BREAKOUT_CFG"` table will be generated. Otherwise, it will not be generated and will work as of today.

[refractored breakout Cli](https://github.com/zhenggen-xu/sonic-utilities/pull/7) PR has a dependency on this PR.

**- How to verify it**

**with platform.json presence**

```
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout$ sudo pytest -s -v --dvsname=vs-sang test_breakout_cli.py
=================================================================== test session starts ====================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout, inifile:
collected 2 items

test_breakout_cli.py::TestBreakoutCli::test_InitialBreakoutMode remove extra link dummy
PASSED                                                                               [ 50%]
test_breakout_cli.py::TestBreakoutCli::test_breakout_modes **** Breakout Cli test Starts ****
**** 1X100G --> 2x50G passed ****
**** 2x50G --> 1x100G[40G] passed ****
**** 1X100G --> 4x25G[10G] passed ****
**** 4x25G[10G] --> 1x100G[40G] passed ****
**** 1X100G --> 2x50G mode change ****
**** 2X50G --> 4x25G[10G] passed ****
**** 4x25G[10G] --> 2X50G passed ****
**** 2x50G  -- > 1X100G mode change ****
**** 1x100G[40G] --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 1x50G(2)+2x25G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 2x50G  mode change ****
**** 2x50G --> 2x25G(2)+1x50G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 2x25G(2)+1x50G(2)  passed ****
**** 2x25G(2)+1x50G(2)  --> 1x100G[40G]  passed ****
PASSED                                                                                    [100%]
```