### PR TITLE
DPB Breakout Cli Test with proper setup

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -41,7 +41,6 @@ RUN apt-get install -y net-tools \
                        libpython2.7 \
                        grub2-common \
                        python-click-default-group \
-                       python-click \
                        python-natsort \
                        python-tabulate \
                        bash-completion \
@@ -51,13 +50,15 @@ RUN apt-get install -y net-tools \
                        apt-utils \
                        psmisc \
                        tcpdump \
-                       python-scapy
+                       python-scapy \
+                       jq
 
 RUN pip install setuptools
 RUN pip install py2_ipaddress
 RUN pip install six
 RUN pip install pyroute2==0.5.3 netifaces==0.10.7
 RUN pip install monotonic==1.5
+RUN pip install click==7.0.0
 
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies
@@ -107,6 +108,7 @@ COPY ["files/arp_update", "/usr/bin/"]
 COPY ["files/buffers_config.j2", "files/qos_config.j2", "/usr/share/sonic/templates/"]
 COPY ["files/sonic_version.yml", "/etc/sonic/"]
 COPY ["database_config.json", "/etc/default/sonic-db/"]
+COPY ["platform.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/platform.json
+++ b/platform/vs/docker-sonic-vs/platform.json
@@ -1,0 +1,226 @@
+{
+    "Ethernet0": {
+        "index": "0,0,0,0",
+        "lanes": "25,26,27,28",
+        "alias_at_lanes": "Eth0/1,Eth0/2,Eth0/3,Eth0/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+   "Ethernet4": {
+        "index": "1,1,1,1",
+        "lanes": "29,30,31,32",
+        "alias_at_lanes": "Eth1/1,Eth1/2,Eth1/3,Eth1/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet8": {
+        "index": "2,2,2,2",
+        "lanes": "33,34,35,36",
+        "alias_at_lanes": "Eth2/1,Eth2/2,Eth2/3,Eth2/4",
+        "breakout_modes": "1x100G[40G],2x50G,2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet12": {
+        "index": "3,3,3,3",
+        "lanes": "37,38,39,40",
+        "alias_at_lanes": "Eth3/1,Eth3/2,Eth3/3,Eth3/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet16": {
+        "index": "4,4,4,4",
+        "lanes": "45,46,47,48",
+        "alias_at_lanes": "Eth4/1,Eth4/2,Eth4/3,Eth4/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet20": {
+        "index": "5,5,5,5",
+        "lanes": "41,42,43,44",
+        "alias_at_lanes": "Eth5/1,Eth5/2,Eth5/3,Eth5/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet24": {
+        "index": "6,6,6,6",
+        "lanes": "1,2,3,4",
+        "alias_at_lanes": "Eth6/1,Eth6/2,Eth6/3,Eth6/4",
+        "breakout_modes": "1x100G[40G],4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet28": {
+        "index": "7,7,7,7",
+        "lanes": "5,6,7,8",
+        "alias_at_lanes": "Eth7/1,Eth7/2,Eth7/3,Eth7/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet32": {
+        "index": "8,8,8,8",
+        "lanes": "13,14,15,16",
+        "alias_at_lanes": "Eth8/1,Eth8/2,Eth8/3,Eth8/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet36": {
+        "index": "9,9,9,9",
+        "lanes": "9,10,11,12",
+        "alias_at_lanes": "Eth9/1,Eth9/2,Eth9/3,Eth9/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet40": {
+        "index": "10,10,10,10",
+        "lanes": "17,18,19,20",
+        "alias_at_lanes": "Eth10/1,Eth10/2,Eth10/3,Eth10/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet44": {
+        "index": "11,11,11,11",
+        "lanes": "21,22,23,24",
+        "alias_at_lanes": "Eth11/1,Eth11/2,Eth11/3,Eth11/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet48": {
+        "index": "12,12,12,12",
+        "lanes": "53,54,55,56",
+        "alias_at_lanes": "Eth12/1,Eth12/2,Eth12/3,Eth12/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet52": {
+        "index": "13,13,13,13",
+        "lanes": "49,50,51,52",
+        "alias_at_lanes": "Eth13/1,Eth13/2,Eth13/3,Eth13/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet56": {
+        "index": "14,14,14,14",
+        "lanes": "57,58,59,60",
+        "alias_at_lanes": "Eth14/1,Eth14/2,Eth14/3,Eth14/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet60": {
+        "index": "15,15,15,15",
+        "lanes": "61,62,63,64",
+        "alias_at_lanes": "Eth15/1,Eth15/2,Eth15/3,Eth15/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet64": {
+        "index": "16,16,16,16",
+        "lanes": "69,70,71,72",
+        "alias_at_lanes": "Eth16/1,Eth16/2,Eth16/3,Eth16/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet68": {
+        "index": "17,17,17,17",
+        "lanes": "65,66,67,68",
+        "alias_at_lanes": "Eth17/1,Eth17/2,Eth17/3,Eth17/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet72": {
+        "index": "18,18,18,18",
+        "lanes": "73,74,75,76",
+        "alias_at_lanes": "Eth18/1,Eth18/2,Eth18/3,Eth18/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet76": {
+        "index": "19,19,19,19",
+        "lanes": "77,78,79,80",
+        "alias_at_lanes": "Eth19/1,Eth19/2,Eth19/3,Eth19/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet80": {
+        "index": "20,20,20,20",
+        "lanes": "109,110,111,112",
+        "alias_at_lanes": "Eth20/1,Eth20/2,Eth20/3,Eth20/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet84": {
+        "index": "21,21,21,21",
+        "lanes": "105,106,107,108",
+        "alias_at_lanes": "Eth21/1,Eth21/2,Eth21/3,Eth21/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet88": {
+        "index": "22,22,22,22",
+        "lanes": "113,114,115,116",
+        "alias_at_lanes": "Eth22/1,Eth22/2,Eth22/3,Eth22/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet92": {
+        "index": "23,23,23,23",
+        "lanes": "117,118,119,120",
+        "alias_at_lanes": "Eth23/1,Eth23/2,Eth23/3,Eth23/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet96": {
+        "index": "24,24,24,24",
+        "lanes": "125,126,127,128",
+        "alias_at_lanes": "Eth24/1,Eth24/2,Eth24/3,Eth24/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet100": {
+        "index": "25,25,25,25",
+        "lanes": "121,122,123,124",
+        "alias_at_lanes": "Eth25/1,Eth25/2,Eth25/3,Eth25/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet104": {
+        "index": "26,26,26,26",
+        "lanes": "81,82,83,84",
+        "alias_at_lanes": "Eth26/1,Eth26/2,Eth26/3,Eth26/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet108": {
+        "index": "27,27,27,27",
+        "lanes": "85,86,87,88",
+        "alias_at_lanes": "Eth27/1,Eth27/2,Eth27/3,Eth27/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet112": {
+        "index": "28,28,28,28",
+        "lanes": "93,94,95,96",
+        "alias_at_lanes": "Eth28/1,Eth28/2,Eth28/3,Eth28/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet116": {
+        "index": "29,29,29,29",
+        "lanes": "89,90,91,92",
+        "alias_at_lanes": "Eth29/1,Eth29/2,Eth29/3,Eth29/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet120": {
+        "index": "30,30,30,30",
+        "lanes": "101,102,103,104",
+        "alias_at_lanes": "Eth30/1,Eth30/2,Eth30/3,Eth30/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    },
+    "Ethernet124": {
+        "index": "31,31,31,31",
+        "lanes": "97,98,99,100",
+        "alias_at_lanes": "Eth31/1,Eth31/2,Eth31/3,Eth31/4",
+        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
+        "default_brkout_mode": "1x100G[40G]"
+    }
+}

--- a/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
+++ b/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
@@ -100,6 +100,52 @@
 	        "index": "0"
 		}
     },
+    "Ethernet4_4x25G": {
+	"Ethernet6": {
+		"alias": "Eth1/3",
+		"admin_status": "up",
+		"lanes": "31",
+		"speed": "25000",
+		"index": "1"
+	},
+	"Ethernet7": {
+		"alias": "Eth1/4",
+		"admin_status": "up",
+		"lanes": "32",
+		"speed": "25000",
+		"index": "1"
+	},
+	"Ethernet4": {
+		"alias": "Eth1/1",
+		"admin_status": "up",
+		"lanes": "29",
+		"speed": "25000",
+		"index": "1"
+	},
+	"Ethernet5": {
+		"alias": "Eth1/2",
+		"admin_status": "up",
+		"lanes": "30",
+		"speed": "25000",
+		"index": "1"
+	}
+    },
+    "Ethernet4_2x50G": {
+        "Ethernet6": {
+		"alias": "Eth1/3",
+		"admin_status": "up",
+		"lanes": "31,32",
+		"speed": "50000",
+		"index": "1"
+	},
+	"Ethernet4": {
+		"alias": "Eth1/1",
+		"admin_status": "up",
+		"lanes": "29,30",
+		"speed": "50000",
+		"index": "1"
+	}
+    },
     "Ethernet8_2x50G": {
 	    "Ethernet8": {
 	        "alias": "Eth2/1",

--- a/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
+++ b/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
@@ -1,0 +1,167 @@
+{
+    "Ethernet0_2x50G": {
+	    "Ethernet2": {
+	        "alias": "Eth0/3",
+	        "admin_status": "up",
+	        "lanes": "27,28",
+	        "speed": "50000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "Eth0/1",
+	        "admin_status": "up",
+	        "lanes": "25,26",
+	        "speed": "50000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet0_1x100G": {
+	    "Ethernet0": {
+	        "alias": "Eth0/1",
+	        "admin_status": "up",
+	        "lanes": "25,26,27,28",
+	        "speed": "100000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet0_4x25G":	{
+	    "Ethernet2": {
+	        "alias": "Eth0/3",
+	        "admin_status": "up",
+	        "lanes": "27",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet3": {
+	        "alias": "Eth0/4",
+	        "admin_status": "up",
+	        "lanes": "28",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "Eth0/1",
+	        "admin_status": "up",
+	        "lanes": "25",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet1": {
+	        "alias": "Eth0/2",
+	        "admin_status": "up",
+	        "lanes": "26",
+	        "speed": "25000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet0_2x25G_1x50G": {
+	    "Ethernet2": {
+	        "alias": "Eth0/3",
+	        "admin_status": "up",
+	        "lanes": "27,28",
+	        "speed": "50000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "Eth0/1",
+	        "admin_status": "up",
+	        "lanes": "25",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet1": {
+	        "alias": "Eth0/2",
+	        "admin_status": "up",
+	        "lanes": "26",
+	        "speed": "25000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet0_1x50G_2x25G": {
+	    "Ethernet2": {
+	        "alias": "Eth0/3",
+	        "admin_status": "up",
+	        "lanes": "27",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet3": {
+	        "alias": "Eth0/4",
+	        "admin_status": "up",
+	        "lanes": "28",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "Eth0/1",
+	        "admin_status": "up",
+	        "lanes": "25,26",
+	        "speed": "50000",
+	        "index": "0"
+		}
+    },
+    "Ethernet8_2x50G": {
+	    "Ethernet8": {
+	        "alias": "Eth2/1",
+	        "admin_status": "up",
+	        "lanes": "33,34",
+	        "speed": "50000",
+	        "index": "2"
+	    },
+	    "Ethernet10": {
+	        "alias": "Eth2/3",
+	        "admin_status": "up",
+	        "lanes": "35,36",
+	        "speed": "50000",
+	        "index": "2"
+	    }
+    },
+    "Ethernet8_1x50G_2x25G": {
+	    "Ethernet10": {
+	        "alias": "Eth2/3",
+	        "admin_status": "up",
+	        "lanes": "35",
+	        "speed": "25000",
+	        "index": "2"
+	    },
+	    "Ethernet11": {
+	        "alias": "Eth2/4",
+	        "admin_status": "up",
+	        "lanes": "36",
+	        "speed": "25000",
+	        "index": "2"
+	    }
+    },
+    "Ethernet8_2x25G_1x50G": {
+	    "Ethernet8": {
+	        "alias": "Eth2/1",
+	        "admin_status": "up",
+	        "lanes": "33",
+	        "speed": "25000",
+	        "index": "2"
+	    },
+	    "Ethernet9": {
+	        "alias": "Eth2/2",
+	        "admin_status": "up",
+	        "lanes": "34",
+	        "speed": "25000",
+	        "index": "2"
+	    },
+	    "Ethernet10": {
+	        "alias": "Eth2/3",
+	        "admin_status": "up",
+	        "lanes": "35,36",
+	        "speed": "50000",
+	        "index": "2"
+	    }
+    },
+    "Ethernet8_1x100G": {
+	    "Ethernet8": {
+	        "alias": "Eth2/1",
+	        "admin_status": "up",
+	        "lanes": "33,34,35,36",
+	        "speed": "100000",
+	        "index": "2"
+	    }
+    }
+}

--- a/platform/vs/tests/breakout/test_breakout_cli.py
+++ b/platform/vs/tests/breakout/test_breakout_cli.py
@@ -1,0 +1,123 @@
+from swsscommon import swsscommon
+import time
+import os
+import json
+import ast
+import pytest
+import collections
+
+@pytest.mark.usefixtures('dpb_setup_fixture')
+class TestBreakoutCli(object):
+    def setup_db(self, dvs):
+        self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+    def read_Json(self, dvs):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        sample_output_file = os.path.join(test_dir, 'sample_output', 'sample_new_port_config.json')
+        fh = open(sample_output_file, 'rb')
+        fh_data = json.load(fh)
+        fh.close()
+
+        if not fh_data:
+            return False
+        expected = ast.literal_eval(json.dumps(fh_data))
+        return expected
+
+    def breakout(self, dvs, interface, brkout_mode):
+        (exitcode, result) = dvs.runcmd("config interface breakout {} {} -y".format(interface, brkout_mode))
+
+        if result.strip("\n")[0] == "[ERROR] Breakout feature is not available without platform.json file" :
+            pytest.exit("**** This test is not needed ****")
+        root_dir = os.path.dirname('/')
+        (exitcode, output_dict) = dvs.runcmd("jq '.' new_port_config.json")
+        if output_dict is None:
+            raise Exception("Breakout output cant be None")
+
+        output_dict = ast.literal_eval(output_dict.strip())
+        return output_dict
+
+    # Check Initial Brakout Mode
+    def test_InitialBreakoutMode(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        output_dict = {}
+        brkoutTbl = swsscommon.Table(self.cdb, "BREAKOUT_CFG")
+        brkout_entries = brkoutTbl.getKeys()
+        assert len(brkout_entries) == 32
+
+        for key in brkout_entries:
+            (status, fvs) = brkoutTbl.get(key)
+            assert(status == True)
+
+            brkout_mode = fvs[0][1]
+            output_dict[key] = brkout_mode
+        output = collections.OrderedDict(sorted(output_dict.items(), key=lambda t: t[0]))
+        expected_dict = {'Ethernet8': '1x100G[40G]', 'Ethernet0': '1x100G[40G]', 'Ethernet4': '1x100G[40G]', 'Ethernet108': '1x100G[40G]', 'Ethernet100': '1x100G[40G]', 'Ethernet104': '1x100G[40G]', 'Ethernet68': '1x100G[40G]', 'Ethernet96': '1x100G[40G]', 'Ethernet124': '1x100G[40G]', 'Ethernet92': '1x100G[40G]', 'Ethernet120': '1x100G[40G]', 'Ethernet52': '1x100G[40G]', 'Ethernet56': '1x100G[40G]', 'Ethernet76': '1x100G[40G]', 'Ethernet72': '1x100G[40G]', 'Ethernet32': '1x100G[40G]', 'Ethernet16': '1x100G[40G]', 'Ethernet36': '1x100G[40G]', 'Ethernet12': '1x100G[40G]', 'Ethernet28': '1x100G[40G]', 'Ethernet88': '1x100G[40G]', 'Ethernet116': '1x100G[40G]', 'Ethernet80': '1x100G[40G]', 'Ethernet112': '1x100G[40G]', 'Ethernet84': '1x100G[40G]', 'Ethernet48': '1x100G[40G]', 'Ethernet44': '1x100G[40G]', 'Ethernet40': '1x100G[40G]', 'Ethernet64': '1x100G[40G]', 'Ethernet60': '1x100G[40G]', 'Ethernet20': '1x100G[40G]', 'Ethernet24': '1x100G[40G]'}
+        expected = collections.OrderedDict(sorted(expected_dict.items(), key=lambda t: t[0]))
+        assert output == expected
+
+    # Breakout Cli Test Mode
+    def test_mode_1X100G(self, dvs):
+        expected = self.read_Json(dvs)
+        assert expected
+
+        print "**** Breakout Cli test Starts ****"
+        output_dict = self.breakout(dvs, 'Ethernet0', '2x50G')
+        expected_dict = expected["Ethernet0_2x50G"]
+        assert output_dict == expected_dict
+        print "**** 1X100G --> 2x50G passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print "**** 2x50G --> 1x100G[40G] passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '4x25G[10G]')
+        expected_dict = expected["Ethernet0_4x25G"]
+        assert output_dict == expected_dict
+        print "**** 1X100G --> 4x25G[10G] passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print "**** 4x25G[10G] --> 1x100G[40G] passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '2x25G(2)+1x50G(2)')
+        expected_dict = expected["Ethernet0_2x25G_1x50G"]
+        assert output_dict == expected_dict
+        print "**** 1x100G[40G] --> 2x25G(2)+1x50G(2) passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print "**** 2x25G(2)+1x50G(2) --> 1x100G[40G] passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x50G(2)+2x25G(2)')
+        expected_dict = expected["Ethernet0_1x50G_2x25G"]
+        assert output_dict == expected_dict
+        print "**** 1x100G[40G] --> 1x50G(2)+2x25G(2)  passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print "**** 1x50G(2)+2x25G(2) --> 1x100G[40G] passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '2x50G')
+        expected_dict = expected["Ethernet8_2x50G"]
+        assert output_dict == expected_dict
+        print "**** 1x100G[40G] --> 2x50G  passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '1x50G(2)+2x25G(2)')
+        expected_dict = expected["Ethernet8_1x50G_2x25G"]
+        assert output_dict == expected_dict
+        print "**** 2x50G --> 2x25G(2)+1x50G(2)  passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '2x25G(2)+1x50G(2)')
+        expected_dict = expected["Ethernet8_2x25G_1x50G"]
+        assert output_dict == expected_dict
+        print "**** 1x50G(2)+2x25G(2) --> 2x25G(2)+1x50G(2)  passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '1x100G[40G]')
+        expected_dict = expected["Ethernet8_1x100G"]
+        assert output_dict == expected_dict
+        print "**** 2x25G(2)+1x50G(2)  --> 1x100G[40G]  passed ****"

--- a/platform/vs/tests/breakout/test_breakout_cli.py
+++ b/platform/vs/tests/breakout/test_breakout_cli.py
@@ -52,12 +52,23 @@ class TestBreakoutCli(object):
             brkout_mode = fvs[0][1]
             output_dict[key] = brkout_mode
         output = collections.OrderedDict(sorted(output_dict.items(), key=lambda t: t[0]))
-        expected_dict = {'Ethernet8': '1x100G[40G]', 'Ethernet0': '1x100G[40G]', 'Ethernet4': '1x100G[40G]', 'Ethernet108': '1x100G[40G]', 'Ethernet100': '1x100G[40G]', 'Ethernet104': '1x100G[40G]', 'Ethernet68': '1x100G[40G]', 'Ethernet96': '1x100G[40G]', 'Ethernet124': '1x100G[40G]', 'Ethernet92': '1x100G[40G]', 'Ethernet120': '1x100G[40G]', 'Ethernet52': '1x100G[40G]', 'Ethernet56': '1x100G[40G]', 'Ethernet76': '1x100G[40G]', 'Ethernet72': '1x100G[40G]', 'Ethernet32': '1x100G[40G]', 'Ethernet16': '1x100G[40G]', 'Ethernet36': '1x100G[40G]', 'Ethernet12': '1x100G[40G]', 'Ethernet28': '1x100G[40G]', 'Ethernet88': '1x100G[40G]', 'Ethernet116': '1x100G[40G]', 'Ethernet80': '1x100G[40G]', 'Ethernet112': '1x100G[40G]', 'Ethernet84': '1x100G[40G]', 'Ethernet48': '1x100G[40G]', 'Ethernet44': '1x100G[40G]', 'Ethernet40': '1x100G[40G]', 'Ethernet64': '1x100G[40G]', 'Ethernet60': '1x100G[40G]', 'Ethernet20': '1x100G[40G]', 'Ethernet24': '1x100G[40G]'}
+        expected_dict = \
+                {'Ethernet8': '1x100G[40G]', 'Ethernet0': '1x100G[40G]', 'Ethernet4': '1x100G[40G]', \
+                'Ethernet108': '1x100G[40G]', 'Ethernet100': '1x100G[40G]', 'Ethernet104': '1x100G[40G]', \
+                'Ethernet68': '1x100G[40G]', 'Ethernet96': '1x100G[40G]', 'Ethernet124': '1x100G[40G]', \
+                'Ethernet92': '1x100G[40G]', 'Ethernet120': '1x100G[40G]', 'Ethernet52': '1x100G[40G]', \
+                'Ethernet56': '1x100G[40G]', 'Ethernet76': '1x100G[40G]', 'Ethernet72': '1x100G[40G]', \
+                'Ethernet32': '1x100G[40G]', 'Ethernet16': '1x100G[40G]', 'Ethernet36': '1x100G[40G]', \
+                'Ethernet12': '1x100G[40G]', 'Ethernet28': '1x100G[40G]', 'Ethernet88': '1x100G[40G]', \
+                'Ethernet116': '1x100G[40G]', 'Ethernet80': '1x100G[40G]', 'Ethernet112': '1x100G[40G]', \
+                'Ethernet84': '1x100G[40G]', 'Ethernet48': '1x100G[40G]', 'Ethernet44': '1x100G[40G]', \
+                'Ethernet40': '1x100G[40G]', 'Ethernet64': '1x100G[40G]', 'Ethernet60': '1x100G[40G]', \
+                'Ethernet20': '1x100G[40G]', 'Ethernet24': '1x100G[40G]'}
         expected = collections.OrderedDict(sorted(expected_dict.items(), key=lambda t: t[0]))
         assert output == expected
 
     # Breakout Cli Test Mode
-    def test_mode_1X100G(self, dvs):
+    def test_breakout_modes(self, dvs):
         expected = self.read_Json(dvs)
         assert expected
 
@@ -82,6 +93,22 @@ class TestBreakoutCli(object):
         assert output_dict == expected_dict
         print "**** 4x25G[10G] --> 1x100G[40G] passed ****"
 
+        output_dict = self.breakout(dvs, 'Ethernet4', '2x50G')
+        print "**** 1X100G --> 2x50G mode change ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '4x25G[10G]')
+        expected_dict = expected["Ethernet4_4x25G"]
+        assert output_dict == expected_dict
+        print "**** 2X50G --> 4x25G[10G] passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '2x50G')
+        expected_dict = expected["Ethernet4_2x50G"]
+        assert output_dict == expected_dict
+        print "**** 4x25G[10G] --> 2X50G passed ****"
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '1x100G[40G]')
+        print "**** 2x50G  -- > 1X100G mode change ****"
+
         output_dict = self.breakout(dvs, 'Ethernet0', '2x25G(2)+1x50G(2)')
         expected_dict = expected["Ethernet0_2x25G_1x50G"]
         assert output_dict == expected_dict
@@ -103,9 +130,7 @@ class TestBreakoutCli(object):
         print "**** 1x50G(2)+2x25G(2) --> 1x100G[40G] passed ****"
 
         output_dict = self.breakout(dvs, 'Ethernet8', '2x50G')
-        expected_dict = expected["Ethernet8_2x50G"]
-        assert output_dict == expected_dict
-        print "**** 1x100G[40G] --> 2x50G  passed ****"
+        print "**** 1x100G[40G] --> 2x50G  mode change ****"
 
         output_dict = self.breakout(dvs, 'Ethernet8', '1x50G(2)+2x25G(2)')
         expected_dict = expected["Ethernet8_1x50G_2x25G"]


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**

1. Created "platform.json" for vs docker.
2. Upgrade click to 7.0.0 for vs docker.
3. Added Test case for Breakout Cli

This PR is dependent on [sonic-buildimage/pull/17](https://github.com/zhenggen-xu/sonic-buildimage/pull/17) and [sonic-swss/pull/17](https://github.com/zhenggen-xu/sonic-swss/pull/17)

**- How to verify it**
```


samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout$ sudo pytest -s -v --dvsname=vs-sang test_breakout_cli.py
=================================================================== test session starts ====================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout, inifile:
collected 2 items

test_breakout_cli.py::TestBreakoutCli::test_InitialBreakoutMode remove extra link dummy
PASSED                                                                               [ 50%]
test_breakout_cli.py::TestBreakoutCli::test_breakout_modes **** Breakout Cli test Starts ****
**** 1X100G --> 2x50G passed ****
**** 2x50G --> 1x100G[40G] passed ****
**** 1X100G --> 4x25G[10G] passed ****
**** 4x25G[10G] --> 1x100G[40G] passed ****
**** 1X100G --> 2x50G mode change ****
**** 2X50G --> 4x25G[10G] passed ****
**** 4x25G[10G] --> 2X50G passed ****
**** 2x50G  -- > 1X100G mode change ****
**** 1x100G[40G] --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 1x50G(2)+2x25G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 2x50G  mode change ****
**** 2x50G --> 2x25G(2)+1x50G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 2x25G(2)+1x50G(2)  passed ****
**** 2x25G(2)+1x50G(2)  --> 1x100G[40G]  passed ****
PASSED                                                                                    [100%]

```



