### PR TITLE
add fec in output file

### DIFF
--- a/src/sonic-config-engine/tests/sample_output/platform_output.json
+++ b/src/sonic-config-engine/tests/sample_output/platform_output.json
@@ -42,6 +42,7 @@
   "Ethernet0": {
     "index": "1",
     "lanes": "0,1,2,3",
+    "fec": "rs",
     "description": "Eth1/1",
     "admin_status": "up",
     "mtu": "9100",
@@ -102,6 +103,7 @@
   "Ethernet100": {
     "index": "26",
     "lanes": "100,101,102,103",
+    "fec": "rs",
     "description": "Eth26/1",
     "admin_status": "up",
     "mtu": "9100",
@@ -582,6 +584,7 @@
   "Ethernet80": {
     "index": "21",
     "lanes": "80,81,82,83",
+    "fec": "rs",
     "description": "Eth21/1",
     "admin_status": "up",
     "mtu": "9100",
@@ -692,6 +695,7 @@
   "Ethernet40": {
     "index": "11",
     "lanes": "40,41,42,43",
+    "fec": "rs",
     "description": "Eth11/1",
     "admin_status": "up",
     "mtu": "9100",
@@ -702,6 +706,7 @@
   "Ethernet120": {
     "index": "31",
     "lanes": "120,121,122,123",
+    "fec": "rs",
     "description": "Eth31/1",
     "admin_status": "up",
     "mtu": "9100",
@@ -732,6 +737,7 @@
   "Ethernet60": {
     "index": "16",
     "lanes": "60,61,62,63",
+    "fec": "rs",
     "description": "Eth16/1",
     "admin_status": "up",
     "mtu": "9100",
@@ -762,6 +768,7 @@
   "Ethernet20": {
     "index": "6",
     "lanes": "20,21,22,23",
+    "fec": "rs",
     "description": "Eth6/1",
     "admin_status": "up",
     "mtu": "9100",


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
added "fec" in sample output as `minigraph.py` file adds "fec" on those ports where speed is 100000.


**- How to verify it**

```
samaity@44a48075e9e0:/sonic$ BLDENV=stretch make -f slave.mk target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl-clean
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "vs"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "admin123"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : "y"
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"

samaity@44a48075e9e0:/sonic$ BLDENV=stretch make -f slave.mk target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "vs"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "admin123"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : "y"
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"

samaity@44a48075e9e0:/sonic$ exit
exit
make[1]: Leaving directory '/home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage'
BLDENV=stretch make -f Makefile.work sonic-slave-bash
make[1]: Entering directory '/home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage'
samaity@b32b8f63f49b:/sonic$ exit
```