### PR TITLE
Fix the port index range in sonic_port.yang

### DIFF
--- a/src/sonic-yang-mgmt/yang-models/sonic-port.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-port.yang
@@ -75,7 +75,7 @@ module sonic-port{
 
 				leaf index {
 					type uint8 {
-						range 1..128;
+						range 0..256;
 					}
 				}
 


### PR DESCRIPTION
Fix the port index range in sonic_port.yang

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
