### PR TITLE
Fix sonic-cfggen --hwsku|-k command

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -37,7 +37,7 @@ from functools import partial
 from minigraph import minigraph_encoder
 from minigraph import parse_xml
 from minigraph import parse_device_desc_xml
-from portconfig import get_port_config, get_breakout_mode
+from portconfig import get_port_config, get_port_config_file_name, get_breakout_mode
 from sonic_device_util import get_machine_info
 from sonic_device_util import get_platform_info
 from sonic_device_util import get_system_mac
@@ -227,6 +227,8 @@ def main():
             'hwsku': hwsku
             }}}
         deep_update(data, hardware_data)
+        if args.port_config is None:
+            args.port_config = get_port_config_file_name(hwsku, platform)
         (ports, _) = get_port_config(hwsku, platform, args.port_config)
         if not ports:
             print('Failed to get port config', file=sys.stderr)


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

`sonic-cfggen -H -k` was not properly rendering the data. It was always reading from `config db` first, then platform.json and portconfig_ini respectively which is not the correct behavior.

**- What I did**
Now it's reading data from respective `platform.json`. So we get correct output.

**- How I did it**
checking the `args.port_config` variable. If it's not mentioned, then filename gets provided by `get_port_config_file_name` function by default.

**- How to verify it**

checked the output for all kind of HWSKUs.

1. Seastone-DX010-10-50
2. Seastone-DX010-50-40
3.  Seastone-DX010-25-50
4. Seastone-DX010
5. Seastone-DX010-50

attached two outputs.
```
admin@lnos-x1-a-fab01:~$ sonic-cfggen -H -k Seastone-DX010 --print-data
{
    "BREAKOUT_CFG": {
        "Ethernet0": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet4": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet8": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet12": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet16": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet20": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet24": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet28": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet32": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet36": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet40": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet44": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet48": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet52": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet56": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet60": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet64": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet68": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet72": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet76": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet80": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet84": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet88": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet92": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet96": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet100": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet104": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet108": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet112": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet116": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet120": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet124": {
            "brkout_mode": "1x100G[40G]"
        }
    },
    "DEVICE_METADATA": {
        "localhost": {
            "hwsku": "Seastone-DX010",
            "mac": "00:e0:ec:3c:09:96",
            "platform": "x86_64-cel_seastone-r0"
        }
    },
    "PORT": {
        "Ethernet0": {
            "admin_status": "up",
            "alias": "Eth1/1",
            "index": "1",
            "lanes": "65,66,67,68",
            "speed": "100000"
        },
        "Ethernet4": {
            "admin_status": "up",
            "alias": "Eth2/1",
            "index": "2",
            "lanes": "69,70,71,72",
            "speed": "100000"
        },
        "Ethernet8": {
            "admin_status": "up",
            "alias": "Eth3/1",
            "index": "3",
            "lanes": "73,74,75,76",
            "speed": "100000"
        },
        "Ethernet12": {
            "admin_status": "up",
            "alias": "Eth4/1",
            "index": "4",
            "lanes": "77,78,79,80",
            "speed": "100000"
        },
        "Ethernet16": {
            "admin_status": "up",
            "alias": "Eth5/1",
            "index": "5",
            "lanes": "33,34,35,36",
            "speed": "100000"
        },
        "Ethernet20": {
            "admin_status": "up",
            "alias": "Eth6/1",
            "index": "6",
            "lanes": "37,38,39,40",
            "speed": "100000"
        },
        "Ethernet24": {
            "admin_status": "up",
            "alias": "Eth7/1",
            "index": "7",
            "lanes": "41,42,43,44",
            "speed": "100000"
        },
        "Ethernet28": {
            "admin_status": "up",
            "alias": "Eth8/1",
            "index": "8",
            "lanes": "45,46,47,48",
            "speed": "100000"
        },
        "Ethernet32": {
            "admin_status": "up",
            "alias": "Eth9/1",
            "index": "9",
            "lanes": "49,50,51,52",
            "speed": "100000"
        },
        "Ethernet36": {
            "admin_status": "up",
            "alias": "Eth10/1",
            "index": "10",
            "lanes": "53,54,55,56",
            "speed": "100000"
        },
        "Ethernet40": {
            "admin_status": "up",
            "alias": "Eth11/1",
            "index": "11",
            "lanes": "57,58,59,60",
            "speed": "100000"
        },
        "Ethernet44": {
            "admin_status": "up",
            "alias": "Eth12/1",
            "index": "12",
            "lanes": "61,62,63,64",
            "speed": "100000"
        },
        "Ethernet48": {
            "admin_status": "up",
            "alias": "Eth13/1",
            "index": "13",
            "lanes": "81,82,83,84",
            "speed": "100000"
        },
        "Ethernet52": {
            "admin_status": "up",
            "alias": "Eth14/1",
            "index": "14",
            "lanes": "85,86,87,88",
            "speed": "100000"
        },
        "Ethernet56": {
            "admin_status": "up",
            "alias": "Eth15/1",
            "index": "15",
            "lanes": "89,90,91,92",
            "speed": "100000"
        },
        "Ethernet60": {
            "admin_status": "up",
            "alias": "Eth16/1",
            "index": "16",
            "lanes": "93,94,95,96",
            "speed": "100000"
        },
        "Ethernet64": {
            "admin_status": "up",
            "alias": "Eth17/1",
            "index": "17",
            "lanes": "97,98,99,100",
            "speed": "100000"
        },
        "Ethernet68": {
            "admin_status": "up",
            "alias": "Eth18/1",
            "index": "18",
            "lanes": "101,102,103,104",
            "speed": "100000"
        },
        "Ethernet72": {
            "admin_status": "up",
            "alias": "Eth19/1",
            "index": "19",
            "lanes": "105,106,107,108",
            "speed": "100000"
        },
        "Ethernet76": {
            "admin_status": "up",
            "alias": "Eth20/1",
            "index": "20",
            "lanes": "109,110,111,112",
            "speed": "100000"
        },
        "Ethernet80": {
            "admin_status": "up",
            "alias": "Eth21/1",
            "index": "21",
            "lanes": "1,2,3,4",
            "speed": "100000"
        },
        "Ethernet84": {
            "admin_status": "up",
            "alias": "Eth22/1",
            "index": "22",
            "lanes": "5,6,7,8",
            "speed": "100000"
        },
        "Ethernet88": {
            "admin_status": "up",
            "alias": "Eth23/1",
            "index": "23",
            "lanes": "9,10,11,12",
            "speed": "100000"
        },
        "Ethernet92": {
            "admin_status": "up",
            "alias": "Eth24/1",
            "index": "24",
            "lanes": "13,14,15,16",
            "speed": "100000"
        },
        "Ethernet96": {
            "admin_status": "up",
            "alias": "Eth25/1",
            "index": "25",
            "lanes": "17,18,19,20",
            "speed": "100000"
        },
        "Ethernet100": {
            "admin_status": "up",
            "alias": "Eth26/1",
            "index": "26",
            "lanes": "21,22,23,24",
            "speed": "100000"
        },
        "Ethernet104": {
            "admin_status": "up",
            "alias": "Eth27/1",
            "index": "27",
            "lanes": "25,26,27,28",
            "speed": "100000"
        },
        "Ethernet108": {
            "admin_status": "up",
            "alias": "Eth28/1",
            "index": "28",
            "lanes": "29,30,31,32",
            "speed": "100000"
        },
        "Ethernet112": {
            "admin_status": "up",
            "alias": "Eth29/1",
            "index": "29",
            "lanes": "113,114,115,116",
            "speed": "100000"
        },
        "Ethernet116": {
            "admin_status": "up",
            "alias": "Eth30/1",
            "index": "30",
            "lanes": "117,118,119,120",
            "speed": "100000"
        },
        "Ethernet120": {
            "admin_status": "up",
            "alias": "Eth31/1",
            "index": "31",
            "lanes": "121,122,123,124",
            "speed": "100000"
        },
        "Ethernet124": {
            "admin_status": "up",
            "alias": "Eth32/1",
            "index": "32",
            "lanes": "125,126,127,128",
            "speed": "100000"
        }
    }
}
```

```
admin@lnos-x1-a-fab01:~$ sonic-cfggen -H -k Seastone-DX010-50 --print-data
{
    "BREAKOUT_CFG": {
        "Ethernet0": {
            "brkout_mode": "2x50G"
        },
        "Ethernet4": {
            "brkout_mode": "2x50G"
        },
        "Ethernet8": {
            "brkout_mode": "2x50G"
        },
        "Ethernet12": {
            "brkout_mode": "2x50G"
        },
        "Ethernet16": {
            "brkout_mode": "2x50G"
        },
        "Ethernet20": {
            "brkout_mode": "2x50G"
        },
        "Ethernet24": {
            "brkout_mode": "2x50G"
        },
        "Ethernet28": {
            "brkout_mode": "2x50G"
        },
        "Ethernet32": {
            "brkout_mode": "2x50G"
        },
        "Ethernet36": {
            "brkout_mode": "2x50G"
        },
        "Ethernet40": {
            "brkout_mode": "2x50G"
        },
        "Ethernet44": {
            "brkout_mode": "2x50G"
        },
        "Ethernet48": {
            "brkout_mode": "2x50G"
        },
        "Ethernet52": {
            "brkout_mode": "2x50G"
        },
        "Ethernet56": {
            "brkout_mode": "2x50G"
        },
        "Ethernet60": {
            "brkout_mode": "2x50G"
        },
        "Ethernet64": {
            "brkout_mode": "2x50G"
        },
        "Ethernet68": {
            "brkout_mode": "2x50G"
        },
        "Ethernet72": {
            "brkout_mode": "2x50G"
        },
        "Ethernet76": {
            "brkout_mode": "2x50G"
        },
        "Ethernet80": {
            "brkout_mode": "2x50G"
        },
        "Ethernet84": {
            "brkout_mode": "2x50G"
        },
        "Ethernet88": {
            "brkout_mode": "2x50G"
        },
        "Ethernet92": {
            "brkout_mode": "2x50G"
        },
        "Ethernet96": {
            "brkout_mode": "2x50G"
        },
        "Ethernet100": {
            "brkout_mode": "2x50G"
        },
        "Ethernet104": {
            "brkout_mode": "2x50G"
        },
        "Ethernet108": {
            "brkout_mode": "2x50G"
        },
        "Ethernet112": {
            "brkout_mode": "2x50G"
        },
        "Ethernet116": {
            "brkout_mode": "2x50G"
        },
        "Ethernet120": {
            "brkout_mode": "2x50G"
        },
        "Ethernet124": {
            "brkout_mode": "2x50G"
        }
    },
    "DEVICE_METADATA": {
        "localhost": {
            "hwsku": "Seastone-DX010-50",
            "mac": "00:e0:ec:3c:09:96",
            "platform": "x86_64-cel_seastone-r0"
        }
    },
    "PORT": {
        "Ethernet0": {
            "admin_status": "up",
            "alias": "Eth1/1",
            "index": "1",
            "lanes": "65,66",
            "speed": "50000"
        },
        "Ethernet2": {
            "admin_status": "up",
            "alias": " Eth1/3",
            "index": "1",
            "lanes": "67,68",
            "speed": "50000"
        },
        "Ethernet4": {
            "admin_status": "up",
            "alias": "Eth2/1",
            "index": "2",
            "lanes": "69,70",
            "speed": "50000"
        },
        "Ethernet6": {
            "admin_status": "up",
            "alias": " Eth2/3",
            "index": "2",
            "lanes": "71,72",
            "speed": "50000"
        },
        "Ethernet8": {
            "admin_status": "up",
            "alias": "Eth3/1",
            "index": "3",
            "lanes": "73,74",
            "speed": "50000"
        },
        "Ethernet10": {
            "admin_status": "up",
            "alias": " Eth3/3",
            "index": "3",
            "lanes": "75,76",
            "speed": "50000"
        },
        "Ethernet12": {
            "admin_status": "up",
            "alias": "Eth4/1",
            "index": "4",
            "lanes": "77,78",
            "speed": "50000"
        },
        "Ethernet14": {
            "admin_status": "up",
            "alias": " Eth4/3",
            "index": "4",
            "lanes": "79,80",
            "speed": "50000"
        },
        "Ethernet16": {
            "admin_status": "up",
            "alias": "Eth5/1",
            "index": "5",
            "lanes": "33,34",
            "speed": "50000"
        },
        "Ethernet18": {
            "admin_status": "up",
            "alias": " Eth5/3",
            "index": "5",
            "lanes": "35,36",
            "speed": "50000"
        },
        "Ethernet20": {
            "admin_status": "up",
            "alias": "Eth6/1",
            "index": "6",
            "lanes": "37,38",
            "speed": "50000"
        },
        "Ethernet22": {
            "admin_status": "up",
            "alias": " Eth6/3",
            "index": "6",
            "lanes": "39,40",
            "speed": "50000"
        },
        "Ethernet24": {
            "admin_status": "up",
            "alias": "Eth7/1",
            "index": "7",
            "lanes": "41,42",
            "speed": "50000"
        },
        "Ethernet26": {
            "admin_status": "up",
            "alias": " Eth7/3",
            "index": "7",
            "lanes": "43,44",
            "speed": "50000"
        },
        "Ethernet28": {
            "admin_status": "up",
            "alias": "Eth8/1",
            "index": "8",
            "lanes": "45,46",
            "speed": "50000"
        },
        "Ethernet30": {
            "admin_status": "up",
            "alias": " Eth8/3",
            "index": "8",
            "lanes": "47,48",
            "speed": "50000"
        },
        "Ethernet32": {
            "admin_status": "up",
            "alias": "Eth9/1",
            "index": "9",
            "lanes": "49,50",
            "speed": "50000"
        },
        "Ethernet34": {
            "admin_status": "up",
            "alias": " Eth9/3",
            "index": "9",
            "lanes": "51,52",
            "speed": "50000"
        },
        "Ethernet36": {
            "admin_status": "up",
            "alias": "Eth10/1",
            "index": "10",
            "lanes": "53,54",
            "speed": "50000"
        },
        "Ethernet38": {
            "admin_status": "up",
            "alias": " Eth10/3",
            "index": "10",
            "lanes": "55,56",
            "speed": "50000"
        },
        "Ethernet40": {
            "admin_status": "up",
            "alias": "Eth11/1",
            "index": "11",
            "lanes": "57,58",
            "speed": "50000"
        },
        "Ethernet42": {
            "admin_status": "up",
            "alias": " Eth11/3",
            "index": "11",
            "lanes": "59,60",
            "speed": "50000"
        },
        "Ethernet44": {
            "admin_status": "up",
            "alias": "Eth12/1",
            "index": "12",
            "lanes": "61,62",
            "speed": "50000"
        },
        "Ethernet46": {
            "admin_status": "up",
            "alias": " Eth12/3",
            "index": "12",
            "lanes": "63,64",
            "speed": "50000"
        },
        "Ethernet48": {
            "admin_status": "up",
            "alias": "Eth13/1",
            "index": "13",
            "lanes": "81,82",
            "speed": "50000"
        },
        "Ethernet50": {
            "admin_status": "up",
            "alias": " Eth13/3",
            "index": "13",
            "lanes": "83,84",
            "speed": "50000"
        },
        "Ethernet52": {
            "admin_status": "up",
            "alias": "Eth14/1",
            "index": "14",
            "lanes": "85,86",
            "speed": "50000"
        },
        "Ethernet54": {
            "admin_status": "up",
            "alias": " Eth14/3",
            "index": "14",
            "lanes": "87,88",
            "speed": "50000"
        },
        "Ethernet56": {
            "admin_status": "up",
            "alias": "Eth15/1",
            "index": "15",
            "lanes": "89,90",
            "speed": "50000"
        },
        "Ethernet58": {
            "admin_status": "up",
            "alias": " Eth15/3",
            "index": "15",
            "lanes": "91,92",
            "speed": "50000"
        },
        "Ethernet60": {
            "admin_status": "up",
            "alias": "Eth16/1",
            "index": "16",
            "lanes": "93,94",
            "speed": "50000"
        },
        "Ethernet62": {
            "admin_status": "up",
            "alias": " Eth16/3",
            "index": "16",
            "lanes": "95,96",
            "speed": "50000"
        },
        "Ethernet64": {
            "admin_status": "up",
            "alias": "Eth17/1",
            "index": "17",
            "lanes": "97,98",
            "speed": "50000"
        },
        "Ethernet66": {
            "admin_status": "up",
            "alias": " Eth17/3",
            "index": "17",
            "lanes": "99,100",
            "speed": "50000"
        },
        "Ethernet68": {
            "admin_status": "up",
            "alias": "Eth18/1",
            "index": "18",
            "lanes": "101,102",
            "speed": "50000"
        },
        "Ethernet70": {
            "admin_status": "up",
            "alias": " Eth18/3",
            "index": "18",
            "lanes": "103,104",
            "speed": "50000"
        },
        "Ethernet72": {
            "admin_status": "up",
            "alias": "Eth19/1",
            "index": "19",
            "lanes": "105,106",
            "speed": "50000"
        },
        "Ethernet74": {
            "admin_status": "up",
            "alias": " Eth19/3",
            "index": "19",
            "lanes": "107,108",
            "speed": "50000"
        },
        "Ethernet76": {
            "admin_status": "up",
            "alias": "Eth20/1",
            "index": "20",
            "lanes": "109,110",
            "speed": "50000"
        },
        "Ethernet78": {
            "admin_status": "up",
            "alias": " Eth20/3",
            "index": "20",
            "lanes": "111,112",
            "speed": "50000"
        },
        "Ethernet80": {
            "admin_status": "up",
            "alias": "Eth21/1",
            "index": "21",
            "lanes": "1,2",
            "speed": "50000"
        },
        "Ethernet82": {
            "admin_status": "up",
            "alias": " Eth21/3",
            "index": "21",
            "lanes": "3,4",
            "speed": "50000"
        },
        "Ethernet84": {
            "admin_status": "up",
            "alias": "Eth22/1",
            "index": "22",
            "lanes": "5,6",
            "speed": "50000"
        },
        "Ethernet86": {
            "admin_status": "up",
            "alias": " Eth22/3",
            "index": "22",
            "lanes": "7,8",
            "speed": "50000"
        },
        "Ethernet88": {
            "admin_status": "up",
            "alias": "Eth23/1",
            "index": "23",
            "lanes": "9,10",
            "speed": "50000"
        },
        "Ethernet90": {
            "admin_status": "up",
            "alias": " Eth23/3",
            "index": "23",
            "lanes": "11,12",
            "speed": "50000"
        },
        "Ethernet92": {
            "admin_status": "up",
            "alias": "Eth24/1",
            "index": "24",
            "lanes": "13,14",
            "speed": "50000"
        },
        "Ethernet94": {
            "admin_status": "up",
            "alias": " Eth24/3",
            "index": "24",
            "lanes": "15,16",
            "speed": "50000"
        },
        "Ethernet96": {
            "admin_status": "up",
            "alias": "Eth25/1",
            "index": "25",
            "lanes": "17,18",
            "speed": "50000"
        },
        "Ethernet98": {
            "admin_status": "up",
            "alias": " Eth25/3",
            "index": "25",
            "lanes": "19,20",
            "speed": "50000"
        },
        "Ethernet100": {
            "admin_status": "up",
            "alias": "Eth26/1",
            "index": "26",
            "lanes": "21,22",
            "speed": "50000"
        },
        "Ethernet102": {
            "admin_status": "up",
            "alias": " Eth26/3",
            "index": "26",
            "lanes": "23,24",
            "speed": "50000"
        },
        "Ethernet104": {
            "admin_status": "up",
            "alias": "Eth27/1",
            "index": "27",
            "lanes": "25,26",
            "speed": "50000"
        },
        "Ethernet106": {
            "admin_status": "up",
            "alias": " Eth27/3",
            "index": "27",
            "lanes": "27,28",
            "speed": "50000"
        },
        "Ethernet108": {
            "admin_status": "up",
            "alias": "Eth28/1",
            "index": "28",
            "lanes": "29,30",
            "speed": "50000"
        },
        "Ethernet110": {
            "admin_status": "up",
            "alias": " Eth28/3",
            "index": "28",
            "lanes": "31,32",
            "speed": "50000"
        },
        "Ethernet112": {
            "admin_status": "up",
            "alias": "Eth29/1",
            "index": "29",
            "lanes": "113,114",
            "speed": "50000"
        },
        "Ethernet114": {
            "admin_status": "up",
            "alias": " Eth29/3",
            "index": "29",
            "lanes": "115,116",
            "speed": "50000"
        },
        "Ethernet116": {
            "admin_status": "up",
            "alias": "Eth30/1",
            "index": "30",
            "lanes": "117,118",
            "speed": "50000"
        },
        "Ethernet118": {
            "admin_status": "up",
            "alias": " Eth30/3",
            "index": "30",
            "lanes": "119,120",
            "speed": "50000"
        },
        "Ethernet120": {
            "admin_status": "up",
            "alias": "Eth31/1",
            "index": "31",
            "lanes": "121,122",
            "speed": "50000"
        },
        "Ethernet122": {
            "admin_status": "up",
            "alias": " Eth31/3",
            "index": "31",
            "lanes": "123,124",
            "speed": "50000"
        },
        "Ethernet124": {
            "admin_status": "up",
            "alias": "Eth32/1",
            "index": "32",
            "lanes": "125,126",
            "speed": "50000"
        },
        "Ethernet126": {
            "admin_status": "up",
            "alias": " Eth32/3",
            "index": "32",
            "lanes": "127,128",
            "speed": "50000"
        }
    }
}
```