### PR TITLE
[_sonic_yang_ext.py]: Added support to allow or deny extra tables.

### DIFF
--- a/src/sonic-yang-mgmt/_sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/_sonic_yang_ext.py
@@ -112,11 +112,14 @@ Crop config as per yang models,
 This Function crops from config only those TABLEs, for which yang models is
 provided.
 """
-def cropConfigDB(self, croppedFile=None):
+def cropConfigDB(self, croppedFile=None, allowExtraTables=True):
 
     for table in self.jIn.keys():
         if table not in self.confDbYangMap:
-            del self.jIn[table]
+            if allowExtraTables:
+                del self.jIn[table]
+            else:
+                raise(Exception("No Yang Model Exist for {}".format(table)))
 
     if croppedFile:
         with open(croppedFile, 'w') as f:
@@ -565,14 +568,14 @@ load_data: load Config DB, crop, xlate and create data tree from it.
 input:    data
 returns:  True - success   False - failed
 """
-def load_data(self, configdbJson):
+def load_data(self, configdbJson, allowExtraTables=True):
 
    try:
       self.jIn = configdbJson
       # reset xlate
       self.xlateJson = dict()
       # self.jIn will be cropped
-      self.cropConfigDB("cropped.json")
+      self.cropConfigDB("cropped.json", allowExtraTables)
       # xlated result will be in self.xlateJson
       self.xlateConfigDB()
       #print(self.xlateJson)


### PR DESCRIPTION
This change will have corresponding changes in sonic-utilities.
Note: these changes in sonic-buildimage are safe to merge even without
sonic-utilities changes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
  [_sonic_yang_ext.py]: Added support to allow or deny extra tables.

**- How I did it**
Add extra parameter in load_data and cropConfigDB API, to control whether to allow or deny extra tables.

**- How to verify it**

Do not allow extra tables:
Final list of ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-head', 'sonic-interface', 'sonic-port', 'sonic-portchannel', 'sonic-vlan']
Reading data from Redis configDb
Data Loading Failed
No Yang Model Exist for BREAKOUT_CFG
Failed to break out Port. Error: Failed to load the config. Error: configMgmt Class creation failed

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
