### PR TITLE
[yang-models]: YANG model changes for INTERFACE, VLAN_INTERFACE, LOOP…

### DIFF
--- a/src/sonic-yang-mgmt/tests/yang-model-tests/yangModelTesting.py
+++ b/src/sonic-yang-mgmt/tests/yang-model-tests/yangModelTesting.py
@@ -109,6 +109,14 @@ class YangModelTesting:
             'INTERFACE_IPPREFIX_PORT_MUST_CONDITION_TRUE': {
                 'desc': 'Interface Ip-prefix port-name must condition pass.',
                 'eStr': self.defaultYANGFailure['None']
+            },
+            'VLAN_INTERFACE_IPPREFIX_MUST_CONDITION_FALSE': {
+                'desc': 'Vlan Interface Ip-prefix must condition failure.',
+                'eStr': self.defaultYANGFailure['Must']
+            },
+            'LOOPBACK_IPPREFIX_PORT_MUST_CONDITION_FALSE': {
+                'desc': 'Loopback Ip-prefix port-name must condition failure.',
+                'eStr': self.defaultYANGFailure['Must']
             }
         }
 

--- a/src/sonic-yang-mgmt/tests/yang-model-tests/yangModelTesting.py
+++ b/src/sonic-yang-mgmt/tests/yang-model-tests/yangModelTesting.py
@@ -41,7 +41,8 @@ class YangModelTesting:
             'InvalidValue': ['Invalid value'],
             'LeafRef': ['Leafref', 'non-existing'],
             'When': ['When condition', 'not satisfied'],
-            'Pattern': ['pattern', 'does not satisfy']
+            'Pattern': ['pattern', 'does not satisfy'],
+            'None': ['']
         }
 
         self.ExceptionTests = {
@@ -100,6 +101,14 @@ class YangModelTesting:
             'ACL_RULE_WRONG_INNER_ETHER_TYPE': {
                 'desc': 'Configure INNER_ETHER_TYPE as 0x080C in ACL_RULE.',
                 'eStr': self.defaultYANGFailure['Pattern']
+            },
+            'INTERFACE_IPPREFIX_PORT_MUST_CONDITION_FALSE': {
+                'desc': 'Interface Ip-prefix port-name must condition failure.',
+                'eStr': self.defaultYANGFailure['Must']
+            },
+            'INTERFACE_IPPREFIX_PORT_MUST_CONDITION_TRUE': {
+                'desc': 'Interface Ip-prefix port-name must condition pass.',
+                'eStr': self.defaultYANGFailure['None']
             }
         }
 

--- a/src/sonic-yang-mgmt/tests/yang-model-tests/yangTest.json
+++ b/src/sonic-yang-mgmt/tests/yang-model-tests/yangTest.json
@@ -433,6 +433,38 @@
 		}
 	},
 
+	"VLAN_INTERFACE_IPPREFIX_MUST_CONDITION_FALSE": {
+		"sonic-vlan:sonic-vlan": {
+			"sonic-vlan:VLAN_INTERFACE": {
+				"VLAN_INTERFACE_IPPREFIX_LIST": [{
+					"vlan_name": "Vlan100",
+					"ip-prefix": "2a04:5555:66:7777::1/64",
+					"scope": "global",
+					"family": "IPv6"
+				}]
+			},
+			"sonic-vlan:VLAN": {
+				"VLAN_LIST": [{
+					"vlan_name": "Vlan100",
+					"description": "server_vlan"
+				}]
+			}
+		}
+	},
+
+	"LOOPBACK_IPPREFIX_PORT_MUST_CONDITION_FALSE": {
+		"sonic-loopback-interface:sonic-loopback-interface": {
+			"sonic-loopback-interface:LOOPBACK_INTERFACE": {
+				"LOOPBACK_INTERFACE_IPPREFIX_LIST": [{
+					"loopback_interface_name": "lo1",
+					"ip-prefix": "2a04:5555:66:7777::1/64",
+					"scope": "global",
+					"family": "IPv6"
+				}]
+			}
+		}
+	},
+
 	"INTERFACE_IPPREFIX_PORT_MUST_CONDITION_FALSE": {
 		"sonic-interface:sonic-interface": {
 			"sonic-interface:INTERFACE": {

--- a/src/sonic-yang-mgmt/tests/yang-model-tests/yangTest.json
+++ b/src/sonic-yang-mgmt/tests/yang-model-tests/yangTest.json
@@ -3,6 +3,9 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_INTERFACE": {
 				"VLAN_INTERFACE_LIST": [{
+					"vlan_name": "Vlan100"
+				}],
+				"VLAN_INTERFACE_IPPREFIX_LIST": [{
 					"vlan_name": "Vlan100",
 					"ip-prefix": "2a04:5555:66:7777::1/64",
 					"scope": "global",
@@ -142,7 +145,10 @@
 		"sonic-interface:sonic-interface": {
 			"sonic-interface:INTERFACE": {
 				"INTERFACE_LIST": [{
-					"interface": "Ethernet8",
+					"port_name": "Ethernet8"
+				}],
+				"INTERFACE_IPPREFIX_LIST": [{
+					"port_name": "Ethernet8",
 					"ip-prefix": "",
 					"scope": "global",
 					"family": "IPv4"
@@ -423,6 +429,70 @@
 						"admin_status": "up"
 					}
 				]
+			}
+		}
+	},
+
+	"INTERFACE_IPPREFIX_PORT_MUST_CONDITION_FALSE": {
+		"sonic-interface:sonic-interface": {
+			"sonic-interface:INTERFACE": {
+				"INTERFACE_LIST": [{
+					"port_name": "Ethernet9"
+				}],
+				"INTERFACE_IPPREFIX_LIST": [{
+					"port_name": "Ethernet8",
+					"ip-prefix": "10.0.0.1/30",
+					"scope": "global",
+					"family": "IPv4"
+				}]
+			}
+		},
+		"sonic-port:sonic-port": {
+			"sonic-port:PORT": {
+				"PORT_LIST": [{
+					"port_name": "Ethernet8",
+					"alias": "eth8",
+					"description": "Ethernet8",
+					"speed": 25000,
+					"mtu": 9000,
+					"admin_status": "up"
+				},
+				{
+					"port_name": "Ethernet9",
+					"alias": "eth9",
+					"description": "Ethernet9",
+					"speed": 25000,
+					"mtu": 9000,
+					"admin_status": "up"
+				}]
+			}
+		}
+	},
+
+	"INTERFACE_IPPREFIX_PORT_MUST_CONDITION_TRUE": {
+		"sonic-interface:sonic-interface": {
+			"sonic-interface:INTERFACE": {
+				"INTERFACE_LIST": [{
+					"port_name": "Ethernet8"
+				}],
+				"INTERFACE_IPPREFIX_LIST": [{
+					"port_name": "Ethernet8",
+					"ip-prefix": "10.0.0.1/30",
+					"scope": "global",
+					"family": "IPv4"
+				}]
+			}
+		},
+		"sonic-port:sonic-port": {
+			"sonic-port:PORT": {
+				"PORT_LIST": [{
+					"port_name": "Ethernet8",
+					"alias": "eth8",
+					"description": "Ethernet8",
+					"speed": 25000,
+					"mtu": 9000,
+					"admin_status": "up"
+				}]
 			}
 		}
 	},

--- a/src/sonic-yang-mgmt/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-interface.yang
@@ -32,15 +32,45 @@ module sonic-interface {
 	}
 
 	container sonic-interface {
+
 		container INTERFACE {
 
 			description "INTERFACE part of config_db.json";
 
 			list INTERFACE_LIST {
 
-				key "interface ip-prefix";
+				description "INTERFACE part of config_db.json with vrf";
 
-				leaf interface {
+				key "port_name";
+
+				leaf port_name {
+					type leafref {
+						path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+					}
+				}
+
+				leaf vrf_name {
+					type string {
+						pattern "Vrf[a-zA-Z0-9_-]+";
+						length 3..255;
+					}
+				}
+			}
+			/* end of INTERFACE_LIST */
+
+			list INTERFACE_IPPREFIX_LIST {
+
+				description "INTERFACE part of config_db.json with ip-prefix";
+
+				key "port_name ip-prefix";
+
+				leaf port_name {
+					/* This node must be present in INTERFACE_LIST */
+					must "(current() = ../../INTERFACE_LIST[port_name=current()]/port_name)"
+					{
+						error-message "Must condition not satisfied, Try adding PORT: {}, Example: 'Ethernet0': {}";
+					}
+
 					type leafref {
 						path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
 					}
@@ -71,7 +101,7 @@ module sonic-interface {
 					type head:ip-family;
 				}
 			}
-			/* end of INTERFACE_LIST */
+			/* end of INTERFACE_IPPREFIX_LIST */
 
 		}
 		/* end of INTERFACE container */

--- a/src/sonic-yang-mgmt/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-loopback-interface.yang
@@ -44,7 +44,7 @@ module sonic-loopback-interface {
             /* end of LOOPBACK_INTERFACE_LIST */
 
             list LOOPBACK_INTERFACE_IPPREFIX_LIST {
-                key "loopback_interface_name ip_prefix";
+                key "loopback_interface_name ip-prefix";
 
                 leaf loopback_interface_name{
                     /* This node must be present in LOOPBACK_INTERFACE_LIST */
@@ -55,7 +55,7 @@ module sonic-loopback-interface {
                     type string;
                 }
 
-                leaf ip_prefix {
+                leaf ip-prefix {
                     type inet:ip-prefix;
                 }
 

--- a/src/sonic-yang-mgmt/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-loopback-interface.yang
@@ -1,0 +1,85 @@
+module sonic-loopback-interface {
+
+    namespace "http://github.com/Azure/sonic-loopback-interface";
+    prefix lointf;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-head {
+        prefix head;
+        revision-date 2019-07-01;
+    }
+
+    organization "Linkedin Corporation";
+
+    contact "lnos_coders@linkedin.com";
+
+    description
+        "SONIC LOOPBACK INTERFACE";
+
+    revision 2020-02-05 {
+        description "First Revision";
+    }
+
+    container sonic-loopback-interface {
+
+        container LOOPBACK_INTERFACE {
+
+            list LOOPBACK_INTERFACE_LIST {
+                key "loopback_interface_name";
+
+                leaf loopback_interface_name{
+                    type string;
+                }
+
+                leaf vrf_name {
+                    type string {
+                        pattern "Vrf[a-zA-Z0-9_-]+";
+                        length 3..255;
+                    }
+                }
+            }
+            /* end of LOOPBACK_INTERFACE_LIST */
+
+            list LOOPBACK_INTERFACE_IPPREFIX_LIST {
+                key "loopback_interface_name ip_prefix";
+
+                leaf loopback_interface_name{
+                    /* This node must be present in LOOPBACK_INTERFACE_LIST */
+                    must "(current() = ../../LOOPBACK_INTERFACE_LIST[loopback_interface_name=current()]/loopback_interface_name)"
+                    {
+                        error-message "Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {}";
+                    }
+                    type string;
+                }
+
+                leaf ip_prefix {
+                    type inet:ip-prefix;
+                }
+
+                leaf scope {
+                    type enumeration {
+                        enum global;
+                        enum local;
+                    }
+                }
+
+                leaf family {
+
+                    /* family leaf needed for backward compatibility
+                       Both ip4 and ip6 address are string in IETF RFC 6021,
+                       so must statement can check based on : or ., family
+                       should be IPv4 or IPv6 according.
+                     */
+
+                    must "(contains(../ip-prefix, ':') and current()='IPv6') or
+                        (contains(../ip-prefix, '.') and current()='IPv4')";
+                    type head:ip-family;
+                }
+            }
+        }
+        /* end of LOOPBACK_INTERFACE_IPPREFIX_LIST */
+    }
+}

--- a/src/sonic-yang-mgmt/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-mgmt/yang-models/sonic-vlan.yang
@@ -32,15 +32,43 @@ module sonic-vlan {
 	}
 
 	container sonic-vlan {
+
 		container VLAN_INTERFACE {
 
 			description "VLAN_INTERFACE part of config_db.json";
 
 			list VLAN_INTERFACE_LIST {
 
+				description "VLAN INTERFACE part of config_db.json with vrf";
+
+				key "vlan_name";
+
+				leaf vlan_name {
+					type leafref {
+						path /vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:vlan_name;
+					}
+				}
+
+				leaf vrf_name {
+					type string {
+						pattern "Vrf[a-zA-Z0-9_-]+";
+						length 3..255;
+					}
+				}
+			}
+			/* end of VLAN_INTERFACE_LIST */
+
+			list VLAN_INTERFACE_IPPREFIX_LIST {
+
 				key "vlan_name ip-prefix";
 
 				leaf vlan_name {
+					/* This node must be present in VLAN_INTERFACE_LIST */
+					must "(current() = ../../VLAN_INTERFACE_LIST[vlan_name=current()]/vlan_name)"
+					{
+						error-message "Must condition not satisfied, Try adding Vlan<vlanid>: {}, Example: 'Vlan100': {}";
+					}
+
 					type leafref {
 						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:vlan_name";
 					}


### PR DESCRIPTION
…BACK_INTERFACE.

Note: Do not Merge till PLY change to process multilist are done.

Changes:
1.) YANG model changes to accommodate VRF feature.
2.) Test case addition for new must condition.
3.) Test case changes for old config for INTERFACE and VLAN_INTERFACE.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1.) YANG model changes to accommodate VRF feature.
2.) Test case addition for new must condition.
3.) Test case changes for old config for INTERFACE and VLAN_INTERFACE.

**- How I did it**
Modified YANG Models.

**- How to verify it**
By YANG Model Testing:
```
pchaudha@e8879b00ab3e:/sonic/src/sonic-yang-mgmt/tests/yang-model-tests$ python yangModelTesting.py -f yangTest.json -y ../../yang-models/ -v > result
DEBUG:YANG-TEST:['sonic-vlan', 'sonic-head', 'sonic-portchannel', 'sonic-acl', 'sonic-loopback-interface', 'sonic-port', 'sonic-interface']
DEBUG:YANG-TEST:sonic-vlan
INFO:YANG-TEST:module: sonic-vlan is loaded successfully
DEBUG:YANG-TEST:sonic-head
ERROR:YANG-TEST:Could not get module: sonic-head
DEBUG:YANG-TEST:sonic-portchannel
INFO:YANG-TEST:module: sonic-portchannel is loaded successfully
DEBUG:YANG-TEST:sonic-acl
INFO:YANG-TEST:module: sonic-acl is loaded successfully
DEBUG:YANG-TEST:sonic-loopback-interface
libyang[1]: Schema node "ip-prefix" not found ((contains(../ip-prefix) with context node "/sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST/family".
libyang[1]: Schema node "ip-prefix" not found ((contains(../ip-prefix, ':') and current()='IPv6') or
(contains(../ip-prefix) with context node "/sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST/family".
INFO:YANG-TEST:module: sonic-loopback-interface is loaded successfully
DEBUG:YANG-TEST:sonic-port
ERROR:YANG-TEST:Could not get module: sonic-port
DEBUG:YANG-TEST:sonic-interface
INFO:YANG-TEST:module: sonic-interface is loaded successfully
INFO:YANG-TEST:
------------------- Test 1: Configure a member port in VLAN_MEMBER table which does not exist.---------------------
DEBUG:YANG-TEST: Read JSON Section: VLAN_WITH_NON_EXIST_PORT
DEBUG:YANG-TEST:{"sonic-vlan:sonic-vlan": {"sonic-vlan:VLAN": {"VLAN_LIST": [{"description": "server_vlan", "vlan_name": "Vlan100"}]}, "sonic-vlan:VLAN_MEMBER": {"VLAN_MEMBER_LIST": [{"tagging_mode": "tagged", "port": "Ethernet156", "vlan_name": "Vlan100"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: Leafref "/sonic-port:sonic-port/sonic-port:PORT/sonic-port:PORT_LIST/sonic-port:port_name" of value "Ethernet156" points to a non-existing leaf. (path: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan100'][port='Ethernet156']/port)
DEBUG:YANG-TEST:Leafref "/sonic-port:sonic-port/sonic-port:PORT/sonic-port:PORT_LIST/sonic-port:port_name" of value "Ethernet156" points to a non-existing leaf.
DEBUG:YANG-TEST:['Leafref', 'non-existing']
INFO:YANG-TEST:Configure a member port in VLAN_MEMBER table which does not exist. Passed

INFO:YANG-TEST:
------------------- Test 2: Configure non-existing ACL_TABLE in ACL_RULE.---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_RULE_WITH_NON_EXIST_ACL_TABLE
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"PRIORITY": 999980, "PACKET_ACTION": "FORWARD", "SRC_IP": "10.176.0.0/15", "RULE_NAME": "Rule_20", "ACL_TABLE_NAME": "NOT-EXIST", "IP_TYPE": "IPv4ANY", "DST_IP": "10.186.72.0/26"}]}, "sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "type": "L3", "policy_desc": "Filter IPv6", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: Leafref "/sonic-acl:sonic-acl/sonic-acl:ACL_TABLE/sonic-acl:ACL_TABLE_LIST/sonic-acl:ACL_TABLE_NAME" of value "NOT-EXIST" points to a non-existing leaf. (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='NOT-EXIST'][RULE_NAME='Rule_20']/ACL_TABLE_NAME)
DEBUG:YANG-TEST:Leafref "/sonic-acl:sonic-acl/sonic-acl:ACL_TABLE/sonic-acl:ACL_TABLE_LIST/sonic-acl:ACL_TABLE_NAME" of value "NOT-EXIST" points to a non-existing leaf.
DEBUG:YANG-TEST:['Leafref', 'non-existing']
INFO:YANG-TEST:Configure non-existing ACL_TABLE in ACL_RULE. Passed

INFO:YANG-TEST:
------------------- Test 3: Configure IP_TYPE as ARP and ICMPV6_CODE in ACL_RULE.---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_RULE_ARP_TYPE_ICMPV6_CODE_MISMATCH
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"PRIORITY": 999960, "PACKET_ACTION": "FORWARD", "SRC_IP": "10.176.0.0/15", "RULE_NAME": "Rule_40", "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "INNER_ETHER_TYPE": "0x88CC", "IP_TYPE": "ARP", "DST_IP": "10.186.72.64/26", "ICMPV6_CODE": 5}]}, "sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "type": "L3", "policy_desc": "Filter IPv4", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: When condition "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])" not satisfied. (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4'][RULE_NAME='Rule_40']/ICMPV6_CODE)
DEBUG:YANG-TEST:When condition "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])" not satisfied.
DEBUG:YANG-TEST:['When condition', 'not satisfied', 'IP_TYPE']
INFO:YANG-TEST:Configure IP_TYPE as ARP and ICMPV6_CODE in ACL_RULE. Passed

INFO:YANG-TEST:
------------------- Test 4: Configure IP_TYPE as ipv4any and SRC_IPV6 in ACL_RULE.---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_RULE_IP_TYPE_SRC_IPV6_MISMATCH
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"SRC_IPV6": "2001::1/64", "PACKET_ACTION": "FORWARD", "PRIORITY": 999980, "RULE_NAME": "Rule_20", "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "IP_TYPE": "IPv4ANY"}]}, "sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "type": "L3", "policy_desc": "Filter IPv4", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: When condition "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])" not satisfied. (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4'][RULE_NAME='Rule_20']/SRC_IPV6)
DEBUG:YANG-TEST:When condition "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])" not satisfied.
DEBUG:YANG-TEST:['When condition', 'not satisfied', 'IP_TYPE']
INFO:YANG-TEST:Configure IP_TYPE as ipv4any and SRC_IPV6 in ACL_RULE. Passed

INFO:YANG-TEST:
------------------- Test 5: Add dhcp_server which is not in correct ip-prefix format.---------------------
DEBUG:YANG-TEST: Read JSON Section: DHCP_SERVER_INCORRECT_FORMAT
DEBUG:YANG-TEST:{"sonic-vlan:sonic-vlan": {"sonic-vlan:VLAN": {"VLAN_LIST": [{"admin_status": "up", "dhcp_servers": ["10.186.72.566"], "description": "server_vlan", "vlan_name": "Vlan100", "mtu": "9216"}]}}}
libyang[0]: Invalid value "10.186.72.566" in "dhcp_servers" element. (path: /sonic-vlan:sonic-vlan/VLAN/VLAN_LIST/dhcp_servers[.='10.186.72.566'])
DEBUG:YANG-TEST:Invalid value "10.186.72.566" in "dhcp_servers" element.
DEBUG:YANG-TEST:['Invalid value', 'dhcp_servers']
INFO:YANG-TEST:Add dhcp_server which is not in correct ip-prefix format. Passed

INFO:YANG-TEST:
------------------- Test 6: Configure undefined acl_table_type in ACL_TABLE table.---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_TABLE_UNDEFINED_TABLE_TYPE
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V6", "type": "LAYER3V4", "policy_desc": "Filter IPv6", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: Invalid value "LAYER3V4" in "type" element. (path: /sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6']/type)
DEBUG:YANG-TEST:Invalid value "LAYER3V4" in "type" element.
DEBUG:YANG-TEST:['Invalid value', 'type']
INFO:YANG-TEST:Configure undefined acl_table_type in ACL_TABLE table. Passed
INFO:YANG-TEST:
------------------- Test 7: Configure INNER_ETHER_TYPE as 0x080C in ACL_RULE.---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_RULE_WRONG_INNER_ETHER_TYPE
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"PRIORITY": 999960, "PACKET_ACTION": "FORWARD", "SRC_IP": "10.176.0.0/15", "RULE_NAME": "Rule_40", "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "INNER_ETHER_TYPE": "0x080C", "IP_TYPE": "ARP", "DST_IP": "10.186.72.64/26"}]}, "sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "type": "L3", "policy_desc": "Filter IPv4", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: Value "0x080C" does not satisfy the constraint "(0x88CC|0x8100|0x8915|0x0806|0x0800|0x86DD|0x8847)" (range, length, or pattern). (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4'][RULE_NAME='Rule_40']/INNER_ETHER_TYPE)
DEBUG:YANG-TEST:Value "0x080C" does not satisfy the constraint "(0x88CC|0x8100|0x8915|0x0806|0x0800|0x86DD|0x8847)" (range, length, or pattern).
DEBUG:YANG-TEST:['pattern', 'does not satisfy']
INFO:YANG-TEST:Configure INNER_ETHER_TYPE as 0x080C in ACL_RULE. Passed

INFO:YANG-TEST:
------------------- Test 8: Configure l4_src_port_range as 99999-99999 in ACL_RULE---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_RULE_WRONG_L4_SRC_PORT_RANGE
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"SRC_IPV6": "2a04:f547:41::/48", "PACKET_ACTION": "FORWARD", "PRIORITY": 999980, "RULE_NAME": "Rule_20", "ACL_TABLE_NAME": "NO-NSW-PACL-V6", "L4_SRC_PORT_RANGE": "99999-99999", "IP_TYPE": "IP", "DST_IPV6": "2a04:f547:43:320::/64"}]}, "sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V6", "type": "L3V6", "policy_desc": "Filter IPv6", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: Value "99999-99999" does not satisfy the constraint "([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])-([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])" (range, length, or pattern). (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6'][RULE_NAME='Rule_20']/L4_SRC_PORT_RANGE)
DEBUG:YANG-TEST:Value "99999-99999" does not satisfy the constraint "([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])-([0-9]{1,4}|[0-5][0-9]{4}|[6][0-4][0-9]{3}|[6][5][0-2][0-9]{2}|[6][5][3][0-5]{2}|[6][5][3][6][0-5])" (range, length, or pattern).
DEBUG:YANG-TEST:['pattern', 'does not satisfy']
INFO:YANG-TEST:Configure l4_src_port_range as 99999-99999 in ACL_RULE Passed

INFO:YANG-TEST:
------------------- Test 9: Configure undefined packet_action in ACL_RULE table.---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_RULE_UNDEFINED_PACKET_ACTION
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"PRIORITY": 999980, "PACKET_ACTION": "SEND", "SRC_IP": "10.176.0.0/15", "RULE_NAME": "Rule_20", "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "IP_TYPE": "IPV4ANY", "DST_IP": "10.186.72.0/26"}]}, "sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "type": "L3", "policy_desc": "Filter IPv4", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: Invalid value "SEND" in "PACKET_ACTION" element. (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST/PACKET_ACTION)
DEBUG:YANG-TEST:Invalid value "SEND" in "PACKET_ACTION" element.
DEBUG:YANG-TEST:['Invalid value', 'PACKET_ACTION']
INFO:YANG-TEST:Configure undefined packet_action in ACL_RULE table. Passed

INFO:YANG-TEST:
------------------- Test 10: Configure wrong value for tagging_mode.---------------------
DEBUG:YANG-TEST: Read JSON Section: TAGGING_MODE_WRONG_VALUE
DEBUG:YANG-TEST:{"sonic-vlan:sonic-vlan": {"sonic-vlan:VLAN": {"VLAN_LIST": [{"description": "server_vlan", "vlan_name": "Vlan100"}]}, "sonic-vlan:VLAN_MEMBER": {"VLAN_MEMBER_LIST": [{"tagging_mode": "non-tagged", "port": "Ethernet0", "vlan_name": 100}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}]}}}
libyang[0]: Invalid value "non-tagged" in "tagging_mode" element. (path: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST/tagging_mode)
DEBUG:YANG-TEST:Invalid value "non-tagged" in "tagging_mode" element.
DEBUG:YANG-TEST:['Invalid value', 'tagging_mode']
INFO:YANG-TEST:Configure wrong value for tagging_mode. Passed

INFO:YANG-TEST:
------------------- Test 11: Interface Ip-prefix port-name must condition failure.---------------------
DEBUG:YANG-TEST: Read JSON Section: INTERFACE_IPPREFIX_PORT_MUST_CONDITION_FALSE
DEBUG:YANG-TEST:{"sonic-interface:sonic-interface": {"sonic-interface:INTERFACE": {"INTERFACE_LIST": [{"port_name": "Ethernet9"}], "INTERFACE_IPPREFIX_LIST": [{"ip-prefix": "10.0.0.1/30", "port_name": "Ethernet8", "family": "IPv4", "scope": "global"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet8", "mtu": 9000, "alias": "eth8", "admin_status": "up", "port_name": "Ethernet8", "speed": 25000}, {"description": "Ethernet9", "mtu": 9000, "alias": "eth9", "admin_status": "up", "port_name": "Ethernet9", "speed": 25000}]}}}
libyang[0]: Must condition "(current() = ../../INTERFACE_LIST[port_name=current()]/port_name)" not satisfied. (path: /sonic-interface:sonic-interface/INTERFACE/INTERFACE_IPPREFIX_LIST[port_name='Ethernet8'][ip-prefix='10.0.0.0/30']/port_name)
libyang[0]: Must condition not satisfied, Try adding PORT: {}, Example: 'Ethernet0': {} (path: /sonic-interface:sonic-interface/INTERFACE/INTERFACE_IPPREFIX_LIST[port_name='Ethernet8'][ip-prefix='10.0.0.0/30']/port_name)
DEBUG:YANG-TEST:Must condition not satisfied, Try adding PORT: {}, Example: 'Ethernet0': {}
DEBUG:YANG-TEST:['Must condition', 'not satisfied']
INFO:YANG-TEST:Interface Ip-prefix port-name must condition failure. Passed

INFO:YANG-TEST:
------------------- Test 12: Interface Ip-prefix port-name must condition pass.---------------------
DEBUG:YANG-TEST: Read JSON Section: INTERFACE_IPPREFIX_PORT_MUST_CONDITION_TRUE
DEBUG:YANG-TEST:{"sonic-interface:sonic-interface": {"sonic-interface:INTERFACE": {"INTERFACE_LIST": [{"port_name": "Ethernet8"}], "INTERFACE_IPPREFIX_LIST": [{"ip-prefix": "10.0.0.1/30", "port_name": "Ethernet8", "family": "IPv4", "scope": "global"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet8", "mtu": 9000, "alias": "eth8", "admin_status": "up", "port_name": "Ethernet8", "speed": 25000}]}}}
DEBUG:YANG-TEST:['']
INFO:YANG-TEST:Interface Ip-prefix port-name must condition pass. Passed

INFO:YANG-TEST:
------------------- Test 13: Configure empty string as ip-prefix in INTERFACE table.---------------------
DEBUG:YANG-TEST: Read JSON Section: INTERFACE_IP_PREFIX_EMPTY_STRING
DEBUG:YANG-TEST:{"sonic-interface:sonic-interface": {"sonic-interface:INTERFACE": {"INTERFACE_LIST": [{"port_name": "Ethernet8"}], "INTERFACE_IPPREFIX_LIST": [{"ip-prefix": "", "port_name": "Ethernet8", "family": "IPv4", "scope": "global"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet8", "mtu": 9000, "alias": "eth8", "admin_status": "up", "port_name": "Ethernet8", "speed": 25000}]}}}
libyang[0]: Invalid value "" in "ip-prefix" element. (path: /sonic-interface:sonic-interface/INTERFACE/INTERFACE_IPPREFIX_LIST[ip-prefix='']/ip-prefix)
DEBUG:YANG-TEST:Invalid value "" in "ip-prefix" element.
DEBUG:YANG-TEST:['Invalid value', 'ip-prefix']
INFO:YANG-TEST:Configure empty string as ip-prefix in INTERFACE table. Passed

INFO:YANG-TEST:
------------------- Test 14: Configure Wrong family with ip-prefix for VLAN_Interface Table---------------------
DEBUG:YANG-TEST: Read JSON Section: WRONG_FAMILY_WITH_IP_PREFIX
DEBUG:YANG-TEST:{"sonic-vlan:sonic-vlan": {"sonic-vlan:VLAN": {"VLAN_LIST": [{"description": "server_vlan", "vlan_name": "Vlan100"}]}, "sonic-vlan:VLAN_INTERFACE": {"VLAN_INTERFACE_IPPREFIX_LIST": [{"ip-prefix": "2a04:5555:66:7777::1/64", "family": "IPv4", "vlan_name": "Vlan100", "scope": "global"}], "VLAN_INTERFACE_LIST": [{"vlan_name": "Vlan100"}]}}}
libyang[0]: Must condition "(contains(../ip-prefix, ':') and current()='IPv6') or                               (contains(../ip-prefix, '.') and current()='IPv4')" not satisfied. (path: /sonic-vlan:sonic-vlan/VLAN_INTERFACE/VLAN_INTERFACE_IPPREFIX_LIST[vlan_name='Vlan100'][ip-prefix='2a04:5555:66:7777::/64']/family)
DEBUG:YANG-TEST:Must condition "(contains(../ip-prefix, ':') and current()='IPv6') or                                   (contains(../ip-prefix, '.') and current()='IPv4')" not satisfied.
DEBUG:YANG-TEST:['Must condition', 'not satisfied']
INFO:YANG-TEST:Configure Wrong family with ip-prefix for VLAN_Interface Table Passed

INFO:YANG-TEST:
------------------- Test 15: Configure vlan-id in VLAN_MEMBER table which does not exist in VLAN  table.---------------------
DEBUG:YANG-TEST: Read JSON Section: VLAN_MEMEBER_WITH_NON_EXIST_VLAN
DEBUG:YANG-TEST:{"sonic-vlan:sonic-vlan": {"sonic-vlan:VLAN": {"VLAN_LIST": [{"description": "server_vlan", "vlan_name": "Vlan100"}, {"description": "ipmi_vlan", "vlan_name": "Vlan300"}]}, "sonic-vlan:VLAN_MEMBER": {"VLAN_MEMBER_LIST": [{"tagging_mode": "tagged", "port": "Ethernet0", "vlan_name": "Vlan200"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}]}}}
libyang[0]: Leafref "/sonic-vlan:sonic-vlan/sonic-vlan:VLAN/sonic-vlan:VLAN_LIST/sonic-vlan:vlan_name" of value "Vlan200" points to a non-existing leaf. (path: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan200'][port='Ethernet0']/vlan_name)
libyang[0]: Leafref "/sonic-vlan:sonic-vlan/sonic-vlan:VLAN/sonic-vlan:VLAN_LIST/sonic-vlan:vlan_name" of value "Vlan200" points to a non-existing leaf. (path: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlan_name='Vlan200'][port='Ethernet0']/vlan_name)
DEBUG:YANG-TEST:Leafref "/sonic-vlan:sonic-vlan/sonic-vlan:VLAN/sonic-vlan:VLAN_LIST/sonic-vlan:vlan_name" of value "Vlan200" points to a non-existing leaf.
DEBUG:YANG-TEST:['Leafref', 'non-existing']
INFO:YANG-TEST:Configure vlan-id in VLAN_MEMBER table which does not exist in VLAN  table. Passed

INFO:YANG-TEST:
------------------- Test 16: Configure IP_TYPE as ARP and DST_IPV6 in ACL_RULE.---------------------
DEBUG:YANG-TEST: Read JSON Section: ACL_RULE_ARP_TYPE_DST_IPV6_MISMATCH
DEBUG:YANG-TEST:{"sonic-acl:sonic-acl": {"sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"PACKET_ACTION": "FORWARD", "PRIORITY": 999980, "RULE_NAME": "Rule_20", "ACL_TABLE_NAME": "NO-NSW-PACL-V6", "IP_TYPE": "ARP", "DST_IPV6": "2001::2/64"}]}, "sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"ports": ["Ethernet0", "Ethernet1"], "ACL_TABLE_NAME": "NO-NSW-PACL-V6", "type": "L3V6", "policy_desc": "Filter IPv6", "stage": "EGRESS"}]}}, "sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"description": "Ethernet0", "mtu": 9000, "alias": "eth0", "admin_status": "up", "port_name": "Ethernet0", "speed": 25000}, {"description": "Ethernet1", "mtu": 9000, "alias": "eth1", "admin_status": "up", "port_name": "Ethernet1", "speed": 25000}]}}}
libyang[0]: When condition "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])" not satisfied. (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V6'][RULE_NAME='Rule_20']/DST_IPV6)
DEBUG:YANG-TEST:When condition "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV6' or .='IPv6ANY'])" not satisfied.
DEBUG:YANG-TEST:['When condition', 'not satisfied', 'IP_TYPE']
INFO:YANG-TEST:Configure IP_TYPE as ARP and DST_IPV6 in ACL_RULE. Passed

INFO:YANG-TEST:All Test Passed
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
