### PR TITLE
[docker-lldp] Fix lldpcli issue when description has special characters

### DIFF
--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -157,7 +157,7 @@ class LldpManager(object):
 
         # if there is a description available, also configure that
         if port_desc:
-            lldpcli_cmd += " description {}".format(port_desc)
+            lldpcli_cmd += " description '{}'".format(port_desc)
         else:
             log_info("Unable to retrieve description for port '{}'. Not adding port description".format(port_name))
 


### PR DESCRIPTION
[docker-lldp] Fix lldpcli issue when description has special characters

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

This should be back-ported to 201911 and 201811 branch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix lldpcli issue when description has special characters

**- How I did it**
Quote the description field.

**- How to verify it**
Before the fix:
lldpcli configure ports Ethernet96 lldp portidsubtype local 'Eth1/1' description 50G|sonic1|Eth1/3/2
bash: sonic1: command not found
bash: Eth1/3/2: No such file or directory

After fix:
lldpcli configure ports Ethernet96 lldp portidsubtype local 'Eth1/1' description '50G|sonic1|Eth1/3/2'
run successfully.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
