### PR TITLE
[docker-frr] Fix the start.sh where it fails in case no WARM_RESTART in configDB

### DIFF
--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -34,7 +34,7 @@ rm -f /var/run/rsyslogd.pid
 supervisorctl start rsyslogd
 
 # start eoiu pulling, only if configured so
-if [[ $(sonic-cfggen -d -v 'WARM_RESTART.bgp.bgp_eoiu') == 'true' ]]; then
+if [[ ! -z $(sonic-cfggen -d -v 'WARM_RESTART') ]] && [[ $(sonic-cfggen -d -v 'WARM_RESTART.bgp.bgp_eoiu') == 'true' ]]; then
     supervisorctl start bgp_eoiu_marker
 fi
 


### PR DESCRIPTION
[docker-frr] Fix the start.sh where it fails in case no WARM_RESTART in configDB

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

This should be back-ported to 201911 branch too.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
If the configDB has no warm-restart configurations, the start.sh in bgp docker would fail due to python exception as below:
```
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 322, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 300, in main
    print(template.render(data))
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 1, in top-level template code
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 430, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'WARM_RESTART' is undefined
```

**- How I did it**
Check the WARM_RESTART table first.  If does not exist, won't check the bgp_eoiu info to avoid crash.

**- How to verify it**
After the fix:
```
without any warm restart configured or if we do "sudo config warm-restart bgp_eoiu false"
bgp docker will not start the bgp_eoiu_marker

if we do:  "sudo config warm-restart bgp_eoiu true"
We can see bgp_eoiu_marker started.
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
