### PR TITLE
platform.json/hwsku.json format changes

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -108,7 +108,8 @@ COPY ["files/arp_update", "/usr/bin/"]
 COPY ["files/buffers_config.j2", "files/qos_config.j2", "/usr/share/sonic/templates/"]
 COPY ["files/sonic_version.yml", "/etc/sonic/"]
 COPY ["database_config.json", "/etc/default/sonic-db/"]
-COPY ["platform.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/"]
+COPY ["platform.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/"]
+COPY ["hwsku.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/hwsku.json
+++ b/platform/vs/docker-sonic-vs/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet8": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet12": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet20": {
+	    "default_brkout_mode": "1x100G[40G]"	
+        },
+        "Ethernet24": {
+	    "default_brkout_mode": "1x100G[40G]"	
+        },
+        "Ethernet28": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet32": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet36": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet40": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet44": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet48": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet52": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet56": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet60": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet68": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet72": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet76": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet80": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet84": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet88": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet92": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet96": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet100": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet104": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet108": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet112": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet116": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet120": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet124": {
+	    "default_brkout_mode": "1x100G[40G]"
+        }
+    }
+}

--- a/platform/vs/docker-sonic-vs/platform.json
+++ b/platform/vs/docker-sonic-vs/platform.json
@@ -1,226 +1,196 @@
 {
-    "Ethernet0": {
-        "index": "0,0,0,0",
-        "lanes": "25,26,27,28",
-        "alias_at_lanes": "Eth0/1,Eth0/2,Eth0/3,Eth0/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-   "Ethernet4": {
-        "index": "1,1,1,1",
-        "lanes": "29,30,31,32",
-        "alias_at_lanes": "Eth1/1,Eth1/2,Eth1/3,Eth1/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet8": {
-        "index": "2,2,2,2",
-        "lanes": "33,34,35,36",
-        "alias_at_lanes": "Eth2/1,Eth2/2,Eth2/3,Eth2/4",
-        "breakout_modes": "1x100G[40G],2x50G,2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet12": {
-        "index": "3,3,3,3",
-        "lanes": "37,38,39,40",
-        "alias_at_lanes": "Eth3/1,Eth3/2,Eth3/3,Eth3/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet16": {
-        "index": "4,4,4,4",
-        "lanes": "45,46,47,48",
-        "alias_at_lanes": "Eth4/1,Eth4/2,Eth4/3,Eth4/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet20": {
-        "index": "5,5,5,5",
-        "lanes": "41,42,43,44",
-        "alias_at_lanes": "Eth5/1,Eth5/2,Eth5/3,Eth5/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet24": {
-        "index": "6,6,6,6",
-        "lanes": "1,2,3,4",
-        "alias_at_lanes": "Eth6/1,Eth6/2,Eth6/3,Eth6/4",
-        "breakout_modes": "1x100G[40G],4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet28": {
-        "index": "7,7,7,7",
-        "lanes": "5,6,7,8",
-        "alias_at_lanes": "Eth7/1,Eth7/2,Eth7/3,Eth7/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet32": {
-        "index": "8,8,8,8",
-        "lanes": "13,14,15,16",
-        "alias_at_lanes": "Eth8/1,Eth8/2,Eth8/3,Eth8/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet36": {
-        "index": "9,9,9,9",
-        "lanes": "9,10,11,12",
-        "alias_at_lanes": "Eth9/1,Eth9/2,Eth9/3,Eth9/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet40": {
-        "index": "10,10,10,10",
-        "lanes": "17,18,19,20",
-        "alias_at_lanes": "Eth10/1,Eth10/2,Eth10/3,Eth10/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet44": {
-        "index": "11,11,11,11",
-        "lanes": "21,22,23,24",
-        "alias_at_lanes": "Eth11/1,Eth11/2,Eth11/3,Eth11/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet48": {
-        "index": "12,12,12,12",
-        "lanes": "53,54,55,56",
-        "alias_at_lanes": "Eth12/1,Eth12/2,Eth12/3,Eth12/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet52": {
-        "index": "13,13,13,13",
-        "lanes": "49,50,51,52",
-        "alias_at_lanes": "Eth13/1,Eth13/2,Eth13/3,Eth13/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet56": {
-        "index": "14,14,14,14",
-        "lanes": "57,58,59,60",
-        "alias_at_lanes": "Eth14/1,Eth14/2,Eth14/3,Eth14/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet60": {
-        "index": "15,15,15,15",
-        "lanes": "61,62,63,64",
-        "alias_at_lanes": "Eth15/1,Eth15/2,Eth15/3,Eth15/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet64": {
-        "index": "16,16,16,16",
-        "lanes": "69,70,71,72",
-        "alias_at_lanes": "Eth16/1,Eth16/2,Eth16/3,Eth16/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet68": {
-        "index": "17,17,17,17",
-        "lanes": "65,66,67,68",
-        "alias_at_lanes": "Eth17/1,Eth17/2,Eth17/3,Eth17/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet72": {
-        "index": "18,18,18,18",
-        "lanes": "73,74,75,76",
-        "alias_at_lanes": "Eth18/1,Eth18/2,Eth18/3,Eth18/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet76": {
-        "index": "19,19,19,19",
-        "lanes": "77,78,79,80",
-        "alias_at_lanes": "Eth19/1,Eth19/2,Eth19/3,Eth19/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet80": {
-        "index": "20,20,20,20",
-        "lanes": "109,110,111,112",
-        "alias_at_lanes": "Eth20/1,Eth20/2,Eth20/3,Eth20/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet84": {
-        "index": "21,21,21,21",
-        "lanes": "105,106,107,108",
-        "alias_at_lanes": "Eth21/1,Eth21/2,Eth21/3,Eth21/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet88": {
-        "index": "22,22,22,22",
-        "lanes": "113,114,115,116",
-        "alias_at_lanes": "Eth22/1,Eth22/2,Eth22/3,Eth22/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet92": {
-        "index": "23,23,23,23",
-        "lanes": "117,118,119,120",
-        "alias_at_lanes": "Eth23/1,Eth23/2,Eth23/3,Eth23/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet96": {
-        "index": "24,24,24,24",
-        "lanes": "125,126,127,128",
-        "alias_at_lanes": "Eth24/1,Eth24/2,Eth24/3,Eth24/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet100": {
-        "index": "25,25,25,25",
-        "lanes": "121,122,123,124",
-        "alias_at_lanes": "Eth25/1,Eth25/2,Eth25/3,Eth25/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet104": {
-        "index": "26,26,26,26",
-        "lanes": "81,82,83,84",
-        "alias_at_lanes": "Eth26/1,Eth26/2,Eth26/3,Eth26/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet108": {
-        "index": "27,27,27,27",
-        "lanes": "85,86,87,88",
-        "alias_at_lanes": "Eth27/1,Eth27/2,Eth27/3,Eth27/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet112": {
-        "index": "28,28,28,28",
-        "lanes": "93,94,95,96",
-        "alias_at_lanes": "Eth28/1,Eth28/2,Eth28/3,Eth28/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet116": {
-        "index": "29,29,29,29",
-        "lanes": "89,90,91,92",
-        "alias_at_lanes": "Eth29/1,Eth29/2,Eth29/3,Eth29/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet120": {
-        "index": "30,30,30,30",
-        "lanes": "101,102,103,104",
-        "alias_at_lanes": "Eth30/1,Eth30/2,Eth30/3,Eth30/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet124": {
-        "index": "31,31,31,31",
-        "lanes": "97,98,99,100",
-        "alias_at_lanes": "Eth31/1,Eth31/2,Eth31/3,Eth31/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
+    "interfaces": {
+        "Ethernet0": {
+            "index": "0,0,0,0",
+            "lanes": "25,26,27,28",
+            "alias_at_lanes": "Eth0/1,Eth0/2,Eth0/3,Eth0/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+       "Ethernet4": {
+            "index": "1,1,1,1",
+            "lanes": "29,30,31,32",
+            "alias_at_lanes": "Eth1/1,Eth1/2,Eth1/3,Eth1/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet8": {
+            "index": "2,2,2,2",
+            "lanes": "33,34,35,36",
+            "alias_at_lanes": "Eth2/1,Eth2/2,Eth2/3,Eth2/4",
+            "breakout_modes": "1x100G[40G],2x50G,2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet12": {
+            "index": "3,3,3,3",
+            "lanes": "37,38,39,40",
+            "alias_at_lanes": "Eth3/1,Eth3/2,Eth3/3,Eth3/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet16": {
+            "index": "4,4,4,4",
+            "lanes": "45,46,47,48",
+            "alias_at_lanes": "Eth4/1,Eth4/2,Eth4/3,Eth4/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet20": {
+            "index": "5,5,5,5",
+            "lanes": "41,42,43,44",
+            "alias_at_lanes": "Eth5/1,Eth5/2,Eth5/3,Eth5/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet24": {
+            "index": "6,6,6,6",
+            "lanes": "1,2,3,4",
+            "alias_at_lanes": "Eth6/1,Eth6/2,Eth6/3,Eth6/4",
+            "breakout_modes": "1x100G[40G],4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet28": {
+            "index": "7,7,7,7",
+            "lanes": "5,6,7,8",
+            "alias_at_lanes": "Eth7/1,Eth7/2,Eth7/3,Eth7/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet32": {
+            "index": "8,8,8,8",
+            "lanes": "13,14,15,16",
+            "alias_at_lanes": "Eth8/1,Eth8/2,Eth8/3,Eth8/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet36": {
+            "index": "9,9,9,9",
+            "lanes": "9,10,11,12",
+            "alias_at_lanes": "Eth9/1,Eth9/2,Eth9/3,Eth9/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet40": {
+            "index": "10,10,10,10",
+            "lanes": "17,18,19,20",
+            "alias_at_lanes": "Eth10/1,Eth10/2,Eth10/3,Eth10/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet44": {
+            "index": "11,11,11,11",
+            "lanes": "21,22,23,24",
+            "alias_at_lanes": "Eth11/1,Eth11/2,Eth11/3,Eth11/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet48": {
+            "index": "12,12,12,12",
+            "lanes": "53,54,55,56",
+            "alias_at_lanes": "Eth12/1,Eth12/2,Eth12/3,Eth12/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet52": {
+            "index": "13,13,13,13",
+            "lanes": "49,50,51,52",
+            "alias_at_lanes": "Eth13/1,Eth13/2,Eth13/3,Eth13/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet56": {
+            "index": "14,14,14,14",
+            "lanes": "57,58,59,60",
+            "alias_at_lanes": "Eth14/1,Eth14/2,Eth14/3,Eth14/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet60": {
+            "index": "15,15,15,15",
+            "lanes": "61,62,63,64",
+            "alias_at_lanes": "Eth15/1,Eth15/2,Eth15/3,Eth15/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet64": {
+            "index": "16,16,16,16",
+            "lanes": "69,70,71,72",
+            "alias_at_lanes": "Eth16/1,Eth16/2,Eth16/3,Eth16/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet68": {
+            "index": "17,17,17,17",
+            "lanes": "65,66,67,68",
+            "alias_at_lanes": "Eth17/1,Eth17/2,Eth17/3,Eth17/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet72": {
+            "index": "18,18,18,18",
+            "lanes": "73,74,75,76",
+            "alias_at_lanes": "Eth18/1,Eth18/2,Eth18/3,Eth18/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet76": {
+            "index": "19,19,19,19",
+            "lanes": "77,78,79,80",
+            "alias_at_lanes": "Eth19/1,Eth19/2,Eth19/3,Eth19/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet80": {
+            "index": "20,20,20,20",
+            "lanes": "109,110,111,112",
+            "alias_at_lanes": "Eth20/1,Eth20/2,Eth20/3,Eth20/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet84": {
+            "index": "21,21,21,21",
+            "lanes": "105,106,107,108",
+            "alias_at_lanes": "Eth21/1,Eth21/2,Eth21/3,Eth21/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet88": {
+            "index": "22,22,22,22",
+            "lanes": "113,114,115,116",
+            "alias_at_lanes": "Eth22/1,Eth22/2,Eth22/3,Eth22/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet92": {
+            "index": "23,23,23,23",
+            "lanes": "117,118,119,120",
+            "alias_at_lanes": "Eth23/1,Eth23/2,Eth23/3,Eth23/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet96": {
+            "index": "24,24,24,24",
+            "lanes": "125,126,127,128",
+            "alias_at_lanes": "Eth24/1,Eth24/2,Eth24/3,Eth24/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet100": {
+            "index": "25,25,25,25",
+            "lanes": "121,122,123,124",
+            "alias_at_lanes": "Eth25/1,Eth25/2,Eth25/3,Eth25/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet104": {
+            "index": "26,26,26,26",
+            "lanes": "81,82,83,84",
+            "alias_at_lanes": "Eth26/1,Eth26/2,Eth26/3,Eth26/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet108": {
+            "index": "27,27,27,27",
+            "lanes": "85,86,87,88",
+            "alias_at_lanes": "Eth27/1,Eth27/2,Eth27/3,Eth27/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet112": {
+            "index": "28,28,28,28",
+            "lanes": "93,94,95,96",
+            "alias_at_lanes": "Eth28/1,Eth28/2,Eth28/3,Eth28/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet116": {
+            "index": "29,29,29,29",
+            "lanes": "89,90,91,92",
+            "alias_at_lanes": "Eth29/1,Eth29/2,Eth29/3,Eth29/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet120": {
+            "index": "30,30,30,30",
+            "lanes": "101,102,103,104",
+            "alias_at_lanes": "Eth30/1,Eth30/2,Eth30/3,Eth30/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet124": {
+            "index": "31,31,31,31",
+            "lanes": "97,98,99,100",
+            "alias_at_lanes": "Eth31/1,Eth31/2,Eth31/3,Eth31/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        }
     }
 }

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -23,6 +23,7 @@ HWSKU_JSON = 'hwsku.json'
 PORT_STR = "Ethernet"
 BRKOUT_MODE = "default_brkout_mode"
 CUR_BRKOUT_MODE = "brkout_mode"
+INTF_KEY = "interfaces"
 
 BRKOUT_PATTERN = r'(\d{1,3})x(\d{1,3}G)(\[\d{1,3}G\])?(\((\d{1,3})\))?'
 
@@ -208,21 +209,24 @@ def parse_platform_json_file(hwsku_json_file, port_config_file, interface_name=N
     if not hwsku_dict:
         raise Exception("hwsku_dict is none")
 
-    for intf in port_dict:
-        if intf not in hwsku_dict:
+    if INTF_KEY not in port_dict or INTF_KEY not in  hwsku_dict:
+        raise Exception("INTF_KEY is not present in appropriate file")
+
+    for intf in port_dict[INTF_KEY]:
+        if intf not in hwsku_dict[INTF_KEY]:
             raise Exception("{} is not available in hwsku_dict".format(intf))
         if str(interface_name) == intf:
             brkout_mode = target_brkout_mode
         else:
-            brkout_mode = hwsku_dict[intf][BRKOUT_MODE]
+            brkout_mode = hwsku_dict[INTF_KEY][intf][BRKOUT_MODE]
 
-        index = port_dict[intf]['index']
-        alias_at_lanes = port_dict[intf]['alias_at_lanes']
-        lanes = port_dict[intf]['lanes']
+        index = port_dict[INTF_KEY][intf]['index']
+        alias_at_lanes = port_dict[INTF_KEY][intf]['alias_at_lanes']
+        lanes = port_dict[INTF_KEY][intf]['lanes']
 
         # if User does not specify brkout_mode, take default_brkout_mode from hwsku.json
         if brkout_mode is None:
-            brkout_mode = hwsku_dict[intf][BRKOUT_MODE]
+            brkout_mode = hwsku_dict[INTF_KEY][intf][BRKOUT_MODE]
 
         # Get match_list for Asymmetric breakout mode
         if re.search("\+",brkout_mode) is not None:
@@ -285,8 +289,10 @@ def parse_breakout_mode(hwsku_json_file):
     hwsku_dict = readJson(hwsku_json_file)
     if not hwsku_dict:
         raise Exception("hwsku_dict is empty")
+    if INTF_KEY not in  hwsku_dict:
+        raise Exception("INTF_KEY is not present in hwsku_dict")
 
     for intf in hwsku_dict:
         brkout_table[intf] = {}
-        brkout_table[intf][CUR_BRKOUT_MODE] = hwsku_dict[intf][BRKOUT_MODE]
+        brkout_table[intf][CUR_BRKOUT_MODE] = hwsku_dict[INTF_KEY][intf][BRKOUT_MODE]
     return brkout_table

--- a/src/sonic-device-data/tests/platformJson_checker
+++ b/src/sonic-device-data/tests/platformJson_checker
@@ -12,10 +12,11 @@ except NameError:
   basestring = str
 
 # Global variable
-PORT_ATTRIBUTES = ["index", "lanes", "alias_at_lanes", "breakout_modes", "default_brkout_mode"]
+PORT_ATTRIBUTES = ["index", "lanes", "alias_at_lanes", "breakout_modes"]
 ATTR_LEN = len(PORT_ATTRIBUTES)
 PORT_REG = "Ethernet(\d+)"
 PLATFORM_JSON = '*platform.json'
+INTF_KEY = "interfaces"
 
 def usage():
     print "Usage: " + sys.argv[0] + " <platform_json_file>"
@@ -41,7 +42,7 @@ def check_file(platform_json_file):
         platform_file_data = platform_cap_file.read()
         port_dict = json.loads(platform_file_data)
 
-        for each_port in port_dict:
+        for each_port in port_dict[INTF_KEY]:
 
             # Validate port at top level
             port_id = re.search(PORT_REG, each_port)
@@ -49,8 +50,8 @@ def check_file(platform_json_file):
                 print "Error: Unknown Interface " + str(each_port) + " at top level"
                 return False
 
-            total_attr = len(port_dict[each_port].keys())
-            port_attr = port_dict[each_port]
+            total_attr = len(port_dict[INTF_KEY][each_port].keys())
+            port_attr = port_dict[INTF_KEY][each_port]
 
             if total_attr != ATTR_LEN:
                 missing_attr = ', '.join(set(PORT_ATTRIBUTES).difference(list(port_attr)))


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**
Modified code to make it compatible with current platform.json/hwsku.json format changes

dependent on this [PR titled [Seastone] Changes for platform.json/hwsku.json for DPB](https://github.com/zhenggen-xu/sonic-buildimage/pull/43)

Changing format of  **platform.json**  from:
 
```
{
        "Ethernet0": {
            "index": "1,1,1,1",
            "lanes": "65,66,67,68",
            "alias_at_lanes": "Eth1/1, Eth1/2, Eth1/3, Eth1/4",
            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
        },
        "Ethernet4": {
            "index": "2,2,2,2",
            "lanes": "69,70,71,72",
            "alias_at_lanes": "Eth2/1, Eth2/2, Eth2/3, Eth2/4",
            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
        }
}
```
to
```
{
    "interfaces": {
        "Ethernet0": {
            "index": "1,1,1,1",
            "lanes": "65,66,67,68",
            "alias_at_lanes": "Eth1/1, Eth1/2, Eth1/3, Eth1/4",
            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
        },
        "Ethernet4": {
            "index": "2,2,2,2",
            "lanes": "69,70,71,72",
            "alias_at_lanes": "Eth2/1, Eth2/2, Eth2/3, Eth2/4",
            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
        }
    }
}
```
Changing format of  **hwsku.json** from:
```
{
        "Ethernet0": {
            "default_brkout_mode": "1x100G[40G]"
        },
        "Ethernet4": {
            "default_brkout_mode": "1x100G[40G]"
        }
}
```
to
```
{
    "interfaces": {
        "Ethernet0": {
            "default_brkout_mode": "1x100G[40G]"
        },
        "Ethernet4": {
            "default_brkout_mode": "1x100G[40G]"
        }
    }
}
```
**- How I did**
Changed the code and the test script for consistency.

**- How to verify it**
```
samaity@a07fe2458d08:/sonic$ BLDENV=stretch make -f slave.mk target/debs/stretch/sonic-device-data_1.0-1_all.deb
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"
```
**From Logs**
```
File ../../../device/dell/x86_64-dellemc_z9264f_c3538-r0/media_settings.json passed validity check
File ../../../device/celestica/x86_64-cel_seastone-r0/platform.json passed validity check
```
**sonic-device-data_1.0-1_all.deb** got successfully built.
```
samaity@a07fe2458d08:/sonic$ ls -la target/debs/stretch/sonic-dev*
-rw-r--r-- 1 samaity gsamaity 5807304 Feb 11 00:03 target/debs/stretch/sonic-device-data_1.0-1_all.deb
-rw-r--r-- 1 samaity gsamaity   27553 Feb 11 00:03 target/debs/stretch/sonic-device-data_1.0-1_all.deb.log
samaity@a07fe2458d08:/sonic$
```