### PR TITLE
DPB: Dependency check using YANG in VS container

### DIFF
--- a/platform/vs/docker-sonic-vs.mk
+++ b/platform/vs/docker-sonic-vs.mk
@@ -9,9 +9,14 @@ $(DOCKER_SONIC_VS)_DEPENDS += $(SWSS) \
                               $(PYTHON_SWSSCOMMON) \
                               $(LIBTEAMDCT) \
                               $(LIBTEAM_UTILS) \
-                              $(SONIC_DEVICE_DATA)
+                              $(SONIC_DEVICE_DATA) \
+                              $(LIBYANG) \
+                              $(LIBYANG_CPP) \
+                              $(LIBYANG_PY2)
 
 $(DOCKER_SONIC_VS)_PYTHON_DEBS += $(SONIC_UTILS)
+
+$(DOCKER_SONIC_VS)_PYTHON_WHEELS += $(SONIC_YANG_MGMT_PY2)
 
 ifeq ($(INSTALL_DEBUG_TOOLS), y)
 $(DOCKER_SONIC_VS)_DEPENDS += $(SWSS_DBG) \

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -59,6 +59,9 @@ RUN pip install six
 RUN pip install pyroute2==0.5.3 netifaces==0.10.7
 RUN pip install monotonic==1.5
 RUN pip install click==7.0.0
+RUN pip install ijson
+RUN pip install jsondiff
+RUN pip install xmltodict
 
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies
@@ -83,6 +86,21 @@ COPY python-debs/{{ deb }} /debs/
 RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
 {%- endfor %}
 {%- endif %}
+
+{% if docker_sonic_vs_whls.strip() %}
+COPY \
+{% for whl in docker_sonic_vs_whls.split(' ') -%}
+python-wheels/{{ whl }}{{' '}}
+{%- endfor -%}
+python-wheels/
+{%- endif -%}
+
+{% if docker_sonic_vs_whls.strip() %}
+RUN pip install \
+{% for whl in docker_sonic_vs_whls.split(' ') -%}
+python-wheels/{{ whl }}{{' '}}
+{%- endfor %}
+{%- endif -%}
 
 # Clean up
 RUN apt-get clean -y


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added required packages to enabled YANG dependency check for Dynamic Port Breakout in VS container

**- How I did it**
Modified Make and Docker jinja template files
**- How to verify it**
Built VS container and ensured that port breakout command executed successfully

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

TEST:
vapatil@server09:~/workspace/XU_DPB_0206/sonic-buildimage$ docker exec -it vs-vp bash
root@766c4a58e8f9:/# show int status
  Interface            Lanes    Speed    MTU    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0      25,26,27,28     100G   9100   Eth0/1  routed      up       up     N/A         N/A
  Ethernet4      29,30,31,32     100G   9100   Eth1/1  routed      up       up     N/A         N/A
  Ethernet8      33,34,35,36     100G   9100   Eth2/1  routed      up       up     N/A         N/A
 Ethernet12      37,38,39,40     100G   9100   Eth3/1  routed      up       up     N/A         N/A
 Ethernet16      45,46,47,48     100G   9100   Eth4/1  routed      up       up     N/A         N/A
 Ethernet20      41,42,43,44     100G   9100   Eth5/1  routed      up       up     N/A         N/A
 Ethernet24          1,2,3,4     100G   9100   Eth6/1  routed      up       up     N/A         N/A
 Ethernet28          5,6,7,8     100G   9100   Eth7/1  routed      up       up     N/A         N/A
 Ethernet32      13,14,15,16     100G   9100   Eth8/1  routed      up       up     N/A         N/A
 Ethernet36       9,10,11,12     100G   9100   Eth9/1  routed      up       up     N/A         N/A
 Ethernet40      17,18,19,20     100G   9100  Eth10/1  routed      up       up     N/A         N/A
 Ethernet44      21,22,23,24     100G   9100  Eth11/1  routed      up       up     N/A         N/A
 Ethernet48      53,54,55,56     100G   9100  Eth12/1  routed      up       up     N/A         N/A
 Ethernet52      49,50,51,52     100G   9100  Eth13/1  routed      up       up     N/A         N/A
 Ethernet56      57,58,59,60     100G   9100  Eth14/1  routed      up       up     N/A         N/A
 Ethernet60      61,62,63,64     100G   9100  Eth15/1  routed      up       up     N/A         N/A
 Ethernet64      69,70,71,72     100G   9100  Eth16/1  routed      up       up     N/A         N/A
 Ethernet68      65,66,67,68     100G   9100  Eth17/1  routed      up       up     N/A         N/A
 Ethernet72      73,74,75,76     100G   9100  Eth18/1  routed      up       up     N/A         N/A
 Ethernet76      77,78,79,80     100G   9100  Eth19/1  routed      up       up     N/A         N/A
 Ethernet80  109,110,111,112     100G   9100  Eth20/1  routed      up       up     N/A         N/A
 Ethernet84  105,106,107,108     100G   9100  Eth21/1  routed      up       up     N/A         N/A
 Ethernet88  113,114,115,116     100G   9100  Eth22/1  routed      up       up     N/A         N/A
 Ethernet92  117,118,119,120     100G   9100  Eth23/1  routed      up       up     N/A         N/A
 Ethernet96  125,126,127,128     100G   9100  Eth24/1  routed      up       up     N/A         N/A
Ethernet100  121,122,123,124     100G   9100  Eth25/1  routed      up       up     N/A         N/A
Ethernet104      81,82,83,84     100G   9100  Eth26/1  routed      up       up     N/A         N/A
Ethernet108      85,86,87,88     100G   9100  Eth27/1  routed      up       up     N/A         N/A
Ethernet112      93,94,95,96     100G   9100  Eth28/1  routed      up       up     N/A         N/A
Ethernet116      89,90,91,92     100G   9100  Eth29/1  routed      up       up     N/A         N/A
Ethernet120  101,102,103,104     100G   9100  Eth30/1  routed      up       up     N/A         N/A
Ethernet124     97,98,99,100     100G   9100  Eth31/1  routed      up       up     N/A         N/A                                                                  
root@766c4a58e8f9:/# config interface breakout Ethernet0 4x25G[10G] -f -v -y                                                                                        
                                                                                                                                                                    
Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 4x25G[10G]

Ports to be deleted :
 {
    "Ethernet0": "100000"
}
Ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet0": "100000"
}
Final list of ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-vlan', 'sonic-portchannel', 'sonic-port', 'sonic-head', 'sonic-interface']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB

*** Ports have been deleted successfully ***


Verify Port Deletion from Asic DB, Wait...

Start Port Addition
Merge Port Config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB

*** Ports have been added successfully ***

Breakout process got successfully completed.
root@766c4a58e8f9:/# show int status
  Interface            Lanes    Speed    MTU    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0               25      25G    N/A   Eth0/1  routed      up       up     N/A         N/A
  Ethernet1               26      25G   9100   Eth0/2  routed      up       up     N/A         N/A
  Ethernet2               27      25G   9100   Eth0/3  routed      up       up     N/A         N/A
  Ethernet3               28      25G   9100   Eth0/4  routed      up       up     N/A         N/A
  Ethernet4      29,30,31,32     100G   9100   Eth1/1  routed      up       up     N/A         N/A
  Ethernet8      33,34,35,36     100G   9100   Eth2/1  routed      up       up     N/A         N/A
 Ethernet12      37,38,39,40     100G   9100   Eth3/1  routed      up       up     N/A         N/A
 Ethernet16      45,46,47,48     100G   9100   Eth4/1  routed      up       up     N/A         N/A
 Ethernet20      41,42,43,44     100G   9100   Eth5/1  routed      up       up     N/A         N/A
 Ethernet24          1,2,3,4     100G   9100   Eth6/1  routed      up       up     N/A         N/A
 Ethernet28          5,6,7,8     100G   9100   Eth7/1  routed      up       up     N/A         N/A
 Ethernet32      13,14,15,16     100G   9100   Eth8/1  routed      up       up     N/A         N/A
 Ethernet36       9,10,11,12     100G   9100   Eth9/1  routed      up       up     N/A         N/A
 Ethernet40      17,18,19,20     100G   9100  Eth10/1  routed      up       up     N/A         N/A
 Ethernet44      21,22,23,24     100G   9100  Eth11/1  routed      up       up     N/A         N/A
 Ethernet48      53,54,55,56     100G   9100  Eth12/1  routed      up       up     N/A         N/A
 Ethernet52      49,50,51,52     100G   9100  Eth13/1  routed      up       up     N/A         N/A
 Ethernet56      57,58,59,60     100G   9100  Eth14/1  routed      up       up     N/A         N/A
 Ethernet60      61,62,63,64     100G   9100  Eth15/1  routed      up       up     N/A         N/A
 Ethernet64      69,70,71,72     100G   9100  Eth16/1  routed      up       up     N/A         N/A
 Ethernet68      65,66,67,68     100G   9100  Eth17/1  routed      up       up     N/A         N/A
 Ethernet72      73,74,75,76     100G   9100  Eth18/1  routed      up       up     N/A         N/A
 Ethernet76      77,78,79,80     100G   9100  Eth19/1  routed      up       up     N/A         N/A
 Ethernet80  109,110,111,112     100G   9100  Eth20/1  routed      up       up     N/A         N/A
 Ethernet84  105,106,107,108     100G   9100  Eth21/1  routed      up       up     N/A         N/A
 Ethernet88  113,114,115,116     100G   9100  Eth22/1  routed      up       up     N/A         N/A
 Ethernet92  117,118,119,120     100G   9100  Eth23/1  routed      up       up     N/A         N/A
 Ethernet96  125,126,127,128     100G   9100  Eth24/1  routed      up       up     N/A         N/A
Ethernet100  121,122,123,124     100G   9100  Eth25/1  routed      up       up     N/A         N/A
Ethernet104      81,82,83,84     100G   9100  Eth26/1  routed      up       up     N/A         N/A
Ethernet108      85,86,87,88     100G   9100  Eth27/1  routed      up       up     N/A         N/A
Ethernet112      93,94,95,96     100G   9100  Eth28/1  routed      up       up     N/A         N/A
Ethernet116      89,90,91,92     100G   9100  Eth29/1  routed      up       up     N/A         N/A
Ethernet120  101,102,103,104     100G   9100  Eth30/1  routed      up       up     N/A         N/A
Ethernet124     97,98,99,100     100G   9100  Eth31/1  routed      up       up     N/A         N/A
root@766c4a58e8f9:/# config interface breakout Ethernet0 1x100G[40G] -f -v -y

Running Breakout Mode : 4x25G[10G]
Target Breakout Mode : 1x100G[40G]

Ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Ports to be added :
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Final list of ports to be added :
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-vlan', 'sonic-portchannel', 'sonic-port', 'sonic-head', 'sonic-interface']
Reading data from Redis configDb

Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB

*** Ports have been deleted successfully ***


Verify Port Deletion from Asic DB, Wait...

Start Port Addition
Merge Port Config for ['Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB

*** Ports have been added successfully ***

Breakout process got successfully completed.
root@766c4a58e8f9:/# how int status
bash: how: command not found
root@766c4a58e8f9:/# show int status
  Interface            Lanes    Speed    MTU    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0      25,26,27,28     100G    N/A   Eth0/1  routed      up       up     N/A         N/A
  Ethernet4      29,30,31,32     100G   9100   Eth1/1  routed      up       up     N/A         N/A
  Ethernet8      33,34,35,36     100G   9100   Eth2/1  routed      up       up     N/A         N/A
 Ethernet12      37,38,39,40     100G   9100   Eth3/1  routed      up       up     N/A         N/A
 Ethernet16      45,46,47,48     100G   9100   Eth4/1  routed      up       up     N/A         N/A
 Ethernet20      41,42,43,44     100G   9100   Eth5/1  routed      up       up     N/A         N/A
 Ethernet24          1,2,3,4     100G   9100   Eth6/1  routed      up       up     N/A         N/A
 Ethernet28          5,6,7,8     100G   9100   Eth7/1  routed      up       up     N/A         N/A
 Ethernet32      13,14,15,16     100G   9100   Eth8/1  routed      up       up     N/A         N/A
 Ethernet36       9,10,11,12     100G   9100   Eth9/1  routed      up       up     N/A         N/A
 Ethernet40      17,18,19,20     100G   9100  Eth10/1  routed      up       up     N/A         N/A
 Ethernet44      21,22,23,24     100G   9100  Eth11/1  routed      up       up     N/A         N/A
 Ethernet48      53,54,55,56     100G   9100  Eth12/1  routed      up       up     N/A         N/A
 Ethernet52      49,50,51,52     100G   9100  Eth13/1  routed      up       up     N/A         N/A
 Ethernet56      57,58,59,60     100G   9100  Eth14/1  routed      up       up     N/A         N/A
 Ethernet60      61,62,63,64     100G   9100  Eth15/1  routed      up       up     N/A         N/A
 Ethernet64      69,70,71,72     100G   9100  Eth16/1  routed      up       up     N/A         N/A
 Ethernet68      65,66,67,68     100G   9100  Eth17/1  routed      up       up     N/A         N/A
 Ethernet72      73,74,75,76     100G   9100  Eth18/1  routed      up       up     N/A         N/A
 Ethernet76      77,78,79,80     100G   9100  Eth19/1  routed      up       up     N/A         N/A
 Ethernet80  109,110,111,112     100G   9100  Eth20/1  routed      up       up     N/A         N/A
 Ethernet84  105,106,107,108     100G   9100  Eth21/1  routed      up       up     N/A         N/A
 Ethernet88  113,114,115,116     100G   9100  Eth22/1  routed      up       up     N/A         N/A
 Ethernet92  117,118,119,120     100G   9100  Eth23/1  routed      up       up     N/A         N/A
 Ethernet96  125,126,127,128     100G   9100  Eth24/1  routed      up       up     N/A         N/A
Ethernet100  121,122,123,124     100G   9100  Eth25/1  routed      up       up     N/A         N/A
Ethernet104      81,82,83,84     100G   9100  Eth26/1  routed      up       up     N/A         N/A
Ethernet108      85,86,87,88     100G   9100  Eth27/1  routed      up       up     N/A         N/A
Ethernet112      93,94,95,96     100G   9100  Eth28/1  routed      up       up     N/A         N/A
Ethernet116      89,90,91,92     100G   9100  Eth29/1  routed      up       up     N/A         N/A
Ethernet120  101,102,103,104     100G   9100  Eth30/1  routed      up       up     N/A         N/A
Ethernet124     97,98,99,100     100G   9100  Eth31/1  routed      up       up     N/A         N/A
root@766c4a58e8f9:/#
vapatil@server09:~/workspace/XU_DPB_0206/sonic-buildimage$


Ran the existing system test case for DPB: 2 passed in 501.48 seconds, 100%