### PR TITLE
Fix Sonic-config-engine testcase

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -556,7 +556,7 @@ def filter_acl_mirror_table_bindings(acls, neighbors, port_channels):
 #
 ###############################################################################
 
-def parse_xml(filename, platform=None, port_config_file=None):
+def parse_xml(filename, platform=None, port_config_file=None, hwsku_config_file=None):
     root = ET.parse(filename).getroot()
     mini_graph_path = filename
 
@@ -602,7 +602,10 @@ def parse_xml(filename, platform=None, port_config_file=None):
         if child.tag == str(docker_routing_config_mode_qn):
             docker_routing_config_mode = child.text
 
-    (ports, alias_map) = get_port_config(hwsku, platform, port_config_file)
+    if hwsku_config_file:
+        (ports, alias_map) = get_port_config(hwsku, platform, port_config_file, hwsku_config_file)
+    else:
+        (ports, alias_map) = get_port_config(hwsku, platform, port_config_file)
     port_alias_map.update(alias_map)
     for child in root:
         if child.tag == str(QName(ns, "DpgDec")):

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -119,12 +119,10 @@ def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_conf
     if port_config_file.endswith('.json'):
         if not hwsku_config_file:
              hwsku_json_file = get_hwsku_file_name(hwsku, platform)
-             if not hwsku_config_file:
+             if not hwsku_json_file:
                 return ({}, {})
         else:
             hwsku_json_file = hwsku_config_file
-        if not hwsku_json_file:
-            raise Exception("'hwsku_json' file does not exist!!! This file is necessary to proceed forward.")
 
         return parse_platform_json_file(hwsku_json_file, port_config_file)
 

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -88,14 +88,14 @@ def get_hwsku_file_name(hwsku=None, platform=None):
     if hwsku:
         if platform:
             hwsku_candidates_Json.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, HWSKU_JSON))
-        hwsku_candidates_Json.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, hwsku, HWSKU_JSON)
-        hwsku_candidates_Json.append(os.path.join(SONIC_ROOT_PATH, hwsku, HWSKU_JSON)
+        hwsku_candidates_Json.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, hwsku, HWSKU_JSON))
+        hwsku_candidates_Json.append(os.path.join(SONIC_ROOT_PATH, hwsku, HWSKU_JSON))
     for candidate in hwsku_candidates_Json:
         if os.path.isfile(candidate):
             return candidate
     return None
 
-def get_port_config(hwsku=None, platform=None, port_config_file=None):
+def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_config_file=None):
     config_db = db_connect_configdb()
 
     # If available, Read from CONFIG DB first
@@ -114,9 +114,15 @@ def get_port_config(hwsku=None, platform=None, port_config_file=None):
         if not port_config_file:
             return ({}, {})
 
+
     # Read from 'platform.json' file
     if port_config_file.endswith('.json'):
-        hwsku_json_file = get_hwsku_file_name(hwsku, platform)
+        if not hwsku_config_file:
+             hwsku_json_file = get_hwsku_file_name(hwsku, platform)
+             if not hwsku_config_file:
+                return ({}, {})
+        else:
+            hwsku_json_file = hwsku_config_file
         if not hwsku_json_file:
             raise Exception("'hwsku_json' file does not exist!!! This file is necessary to proceed forward.")
 

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -196,6 +196,7 @@ def main():
     group.add_argument("-M", "--device-description", help="device description xml file")
     group.add_argument("-k", "--hwsku", help="HwSKU")
     parser.add_argument("-p", "--port-config", help="port config file, used with -m or -k", nargs='?', const=None)
+    parser.add_argument("-S", "--hwsku-config", help="hwsku config file, used with -p and -m or -k", nargs='?', const=None)
     parser.add_argument("-y", "--yaml", help="yaml file that contains additional variables", action='append', default=[])
     parser.add_argument("-j", "--json", help="json file that contains additional variables", action='append', default=[])
     parser.add_argument("-a", "--additional-data", help="addition data, in json string")
@@ -247,7 +248,7 @@ def main():
             else:
                 deep_update(data, parse_xml(minigraph, platform))
         else:
-            deep_update(data, parse_xml(minigraph, port_config_file=args.port_config))
+            deep_update(data, parse_xml(minigraph, port_config_file=args.port_config, hwsku_config_file=args.hwsku_config))
 
     if args.device_description != None:
         deep_update(data, parse_device_desc_xml(args.device_description))

--- a/src/sonic-config-engine/tests/sample_hwsku.json
+++ b/src/sonic-config-engine/tests/sample_hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "2x25G(2)+1x50G(2)"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "1x50G(2)+2x25G(2)"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "2x50G"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/sample_platform.json
+++ b/src/sonic-config-engine/tests/sample_platform.json
@@ -1,226 +1,196 @@
 {
-    "Ethernet0": {
-        "index": "1,1,1,1",
-        "lanes": "0,1,2,3",
-        "alias_at_lanes": "Eth1/1, Eth1/2, Eth1/3, Eth1/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "1x100G[40G]"
-    },
-   "Ethernet4": {
-        "index": "2,2,2,2",
-        "lanes": "4,5,6,7",
-        "alias_at_lanes": "Eth2/1, Eth2/2, Eth2/3, Eth2/4",
-        "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]",
-        "default_brkout_mode": "2x50G"
-    },
-    "Ethernet8": {
-        "index": "3,3,3,3",
-        "lanes": "8,9,10,11",
-        "alias_at_lanes": "Eth3/1, Eth3/2, Eth3/3, Eth3/4",
-        "breakout_modes": "1x100G[40G],2x50G,2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-        "default_brkout_mode": "4x25G[10G]"
-    },
-    "Ethernet12": {
-	"index": "4,4,4,4",
-	"lanes": "12,13,14,15",
-	"alias_at_lanes": "Eth4/1, Eth4/2, Eth4/3, Eth4/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x25G(2)+1x50G(2)"
-    },
-    "Ethernet16": {
-	"index": "5,5,5,5",
-	"lanes": "16,17,18,19",
-	"alias_at_lanes": "Eth5/1, Eth5/2, Eth5/3, Eth5/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x50G(2)+2x25G(2)"
-    },
-    "Ethernet20": {
-	"index": "6,6,6,6",
-	"lanes": "20,21,22,23",
-	"alias_at_lanes": "Eth6/1, Eth6/2, Eth6/3, Eth6/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet24": {
-	"index": "7,7,7,7",
-	"lanes": "24,25,26,27",
-	"alias_at_lanes": "Eth7/1, Eth7/2, Eth7/3, Eth7/4",
-	"breakout_modes": "1x100G[40G],4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x50G"
-    },
-    "Ethernet28": {
-	"index": "8,8,8,8",
-	"lanes": "28,29,30,31",
-	"alias_at_lanes": "Eth8/1, Eth8/2, Eth8/3, Eth8/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "4x25G[10G]"
-    },
-    "Ethernet32": {
-	"index": "9,9,9,9",
-	"lanes": "32,33,34,35",
-	"alias_at_lanes": "Eth9/1, Eth9/2, Eth9/3, Eth9/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x25G(2)+1x50G(2)"
-    },
-    "Ethernet36": {
-	"index": "10,10,10,10",
-	"lanes": "36,37,38,39",
-	"alias_at_lanes": "Eth10/1, Eth10/2, Eth10/3, Eth10/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x50G(2)+2x25G(2)"
-    },
-    "Ethernet40": {
-	"index": "11,11,11,11",
-	"lanes": "40,41,42,43",
-	"alias_at_lanes": "Eth11/1, Eth11/2, Eth11/3, Eth11/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet44": {
-	"index": "12,12,12,12",
-	"lanes": "44,45,46,47",
-	"alias_at_lanes": "Eth12/1, Eth12/2, Eth12/3, Eth12/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x50G"
-    },
-    "Ethernet48": {
-	"index": "13,13,13,13",
-	"lanes": "48,49,50,51",
-	"alias_at_lanes": "Eth13/1, Eth13/2, Eth13/3, Eth13/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "4x25G[10G]"
-    },
-    "Ethernet52": {
-	"index": "14,14,14,14",
-	"lanes": "52,53,54,55",
-	"alias_at_lanes": "Eth14/1, Eth14/2, Eth14/3, Eth14/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x25G(2)+1x50G(2)"
-    },
-    "Ethernet56": {
-	"index": "15,15,15,15",
-	"lanes": "56,57,58,59",
-	"alias_at_lanes": "Eth15/1, Eth15/2, Eth15/3, Eth15/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x50G(2)+2x25G(2)"
-    },
-    "Ethernet60": {
-	"index": "16,16,16,16",
-	"lanes": "60,61,62,63",
-	"alias_at_lanes": "Eth16/1, Eth16/2, Eth16/3, Eth16/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet64": {
-	"index": "17,17,17,17",
-	"lanes": "64,65,66,67",
-	"alias_at_lanes": "Eth17/1, Eth17/2, Eth17/3, Eth17/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x50G"
-    },
-    "Ethernet68": {
-	"index": "18,18,18,18",
-	"lanes": "68,69,70,71",
-	"alias_at_lanes": "Eth18/1, Eth18/2, Eth18/3, Eth18/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "4x25G[10G]"
-    },
-    "Ethernet72": {
-	"index": "19,19,19,19",
-	"lanes": "72,73,74,75",
-	"alias_at_lanes": "Eth19/1, Eth19/2, Eth19/3, Eth19/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x25G(2)+1x50G(2)"
-    },
-    "Ethernet76": {
-	"index": "20,20,20,20",
-	"lanes": "76,77,78,79",
-	"alias_at_lanes": "Eth20/1, Eth20/2, Eth20/3, Eth20/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x50G(2)+2x25G(2)"
-    },
-    "Ethernet80": {
-	"index": "21,21,21,21",
-	"lanes": "80,81,82,83",
-	"alias_at_lanes": "Eth21/1, Eth21/2, Eth21/3, Eth21/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet84": {
-	"index": "22,22,22,22",
-	"lanes": "84,85,86,87",
-	"alias_at_lanes": "Eth22/1, Eth22/2, Eth22/3, Eth22/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x50G"
-    },
-    "Ethernet88": {
-	"index": "23,23,23,23",
-	"lanes": "88,89,90,91",
-	"alias_at_lanes": "Eth23/1, Eth23/2, Eth23/3, Eth23/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "4x25G[10G]"
-    },
-    "Ethernet92": {
-	"index": "24,24,24,24",
-	"lanes": "92,93,94,95",
-	"alias_at_lanes": "Eth24/1, Eth24/2, Eth24/3, Eth24/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x25G(2)+1x50G(2)"
-    },
-    "Ethernet96": {
-	"index": "25,25,25,25",
-	"lanes": "96,97,98,99",
-	"alias_at_lanes": "Eth25/1, Eth25/2, Eth25/3, Eth25/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x50G(2)+2x25G(2)"
-    },
-    "Ethernet100": {
-	"index": "26,26,26,26",
-	"lanes": "100,101,102,103",
-	"alias_at_lanes": "Eth26/1, Eth26/2, Eth26/3, Eth26/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet104": {
-	"index": "27,27,27,27",
-	"lanes": "104,105,106,107",
-	"alias_at_lanes": "Eth27/1, Eth27/2, Eth27/3, Eth27/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x50G"
-    },
-    "Ethernet108": {
-	"index": "28,28,28,28",
-	"lanes": "108,109,110,111",
-	"alias_at_lanes": "Eth28/1, Eth28/2, Eth28/3, Eth28/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "4x25G[10G]"
-    },
-    "Ethernet112": {
-	"index": "29,29,29,29",
-	"lanes": "112,113,114,115",
-	"alias_at_lanes": "Eth29/1, Eth29/2, Eth29/3, Eth29/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x25G(2)+1x50G(2)"
-    },
-    "Ethernet116": {
-	"index": "30,30,30,30",
-	"lanes": "116,117,118,119",
-	"alias_at_lanes": "Eth30/1, Eth30/2, Eth30/3, Eth30/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x50G(2)+2x25G(2)"
-    },
-    "Ethernet120": {
-	"index": "31,31,31,31",
-	"lanes": "120,121,122,123",
-	"alias_at_lanes": "Eth31/1, Eth31/2, Eth31/3, Eth31/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "1x100G[40G]"
-    },
-    "Ethernet124": {
-	"index": "32,32,32,32",
-	"lanes": "124,125,126,127",
-	"alias_at_lanes": "Eth32/1, Eth32/2, Eth32/3, Eth32/4",
-	"breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)",
-	"default_brkout_mode": "2x50G"
+    "interfaces": {
+        "Ethernet0": {
+            "index": "1,1,1,1",
+            "lanes": "0,1,2,3",
+            "alias_at_lanes": "Eth1/1, Eth1/2, Eth1/3, Eth1/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet4": {
+            "index": "2,2,2,2",
+            "lanes": "4,5,6,7",
+            "alias_at_lanes": "Eth2/1, Eth2/2, Eth2/3, Eth2/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet8": {
+            "index": "3,3,3,3",
+            "lanes": "8,9,10,11",
+            "alias_at_lanes": "Eth3/1, Eth3/2, Eth3/3, Eth3/4",
+            "breakout_modes": "1x100G[40G],2x50G,2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet12": {
+            "index": "4,4,4,4",
+            "lanes": "12,13,14,15",
+            "alias_at_lanes": "Eth4/1, Eth4/2, Eth4/3, Eth4/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet16": {
+            "index": "5,5,5,5",
+            "lanes": "16,17,18,19",
+            "alias_at_lanes": "Eth5/1, Eth5/2, Eth5/3, Eth5/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet20": {
+            "index": "6,6,6,6",
+            "lanes": "20,21,22,23",
+            "alias_at_lanes": "Eth6/1, Eth6/2, Eth6/3, Eth6/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet24": {
+            "index": "7,7,7,7",
+            "lanes": "24,25,26,27",
+            "alias_at_lanes": "Eth7/1, Eth7/2, Eth7/3, Eth7/4",
+            "breakout_modes": "1x100G[40G],4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet28": {
+            "index": "8,8,8,8",
+            "lanes": "28,29,30,31",
+            "alias_at_lanes": "Eth8/1, Eth8/2, Eth8/3, Eth8/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet32": {
+            "index": "9,9,9,9",
+            "lanes": "32,33,34,35",
+            "alias_at_lanes": "Eth9/1, Eth9/2, Eth9/3, Eth9/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet36": {
+            "index": "10,10,10,10",
+            "lanes": "36,37,38,39",
+            "alias_at_lanes": "Eth10/1, Eth10/2, Eth10/3, Eth10/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet40": {
+            "index": "11,11,11,11",
+            "lanes": "40,41,42,43",
+            "alias_at_lanes": "Eth11/1, Eth11/2, Eth11/3, Eth11/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet44": {
+            "index": "12,12,12,12",
+            "lanes": "44,45,46,47",
+            "alias_at_lanes": "Eth12/1, Eth12/2, Eth12/3, Eth12/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet48": {
+            "index": "13,13,13,13",
+            "lanes": "48,49,50,51",
+            "alias_at_lanes": "Eth13/1, Eth13/2, Eth13/3, Eth13/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet52": {
+            "index": "14,14,14,14",
+            "lanes": "52,53,54,55",
+            "alias_at_lanes": "Eth14/1, Eth14/2, Eth14/3, Eth14/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet56": {
+            "index": "15,15,15,15",
+            "lanes": "56,57,58,59",
+            "alias_at_lanes": "Eth15/1, Eth15/2, Eth15/3, Eth15/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet60": {
+            "index": "16,16,16,16",
+            "lanes": "60,61,62,63",
+            "alias_at_lanes": "Eth16/1, Eth16/2, Eth16/3, Eth16/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet64": {
+            "index": "17,17,17,17",
+            "lanes": "64,65,66,67",
+            "alias_at_lanes": "Eth17/1, Eth17/2, Eth17/3, Eth17/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet68": {
+            "index": "18,18,18,18",
+            "lanes": "68,69,70,71",
+            "alias_at_lanes": "Eth18/1, Eth18/2, Eth18/3, Eth18/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet72": {
+            "index": "19,19,19,19",
+            "lanes": "72,73,74,75",
+            "alias_at_lanes": "Eth19/1, Eth19/2, Eth19/3, Eth19/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet76": {
+            "index": "20,20,20,20",
+            "lanes": "76,77,78,79",
+            "alias_at_lanes": "Eth20/1, Eth20/2, Eth20/3, Eth20/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet80": {
+            "index": "21,21,21,21",
+            "lanes": "80,81,82,83",
+            "alias_at_lanes": "Eth21/1, Eth21/2, Eth21/3, Eth21/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet84": {
+            "index": "22,22,22,22",
+            "lanes": "84,85,86,87",
+            "alias_at_lanes": "Eth22/1, Eth22/2, Eth22/3, Eth22/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet88": {
+            "index": "23,23,23,23",
+            "lanes": "88,89,90,91",
+            "alias_at_lanes": "Eth23/1, Eth23/2, Eth23/3, Eth23/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet92": {
+            "index": "24,24,24,24",
+            "lanes": "92,93,94,95",
+            "alias_at_lanes": "Eth24/1, Eth24/2, Eth24/3, Eth24/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet96": {
+            "index": "25,25,25,25",
+            "lanes": "96,97,98,99",
+            "alias_at_lanes": "Eth25/1, Eth25/2, Eth25/3, Eth25/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet100": {
+            "index": "26,26,26,26",
+            "lanes": "100,101,102,103",
+            "alias_at_lanes": "Eth26/1, Eth26/2, Eth26/3, Eth26/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet104": {
+            "index": "27,27,27,27",
+            "lanes": "104,105,106,107",
+            "alias_at_lanes": "Eth27/1, Eth27/2, Eth27/3, Eth27/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet108": {
+            "index": "28,28,28,28",
+            "lanes": "108,109,110,111",
+            "alias_at_lanes": "Eth28/1, Eth28/2, Eth28/3, Eth28/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet112": {
+            "index": "29,29,29,29",
+            "lanes": "112,113,114,115",
+            "alias_at_lanes": "Eth29/1, Eth29/2, Eth29/3, Eth29/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet116": {
+            "index": "30,30,30,30",
+            "lanes": "116,117,118,119",
+            "alias_at_lanes": "Eth30/1, Eth30/2, Eth30/3, Eth30/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet120": {
+            "index": "31,31,31,31",
+            "lanes": "120,121,122,123",
+            "alias_at_lanes": "Eth31/1, Eth31/2, Eth31/3, Eth31/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet124": {
+            "index": "32,32,32,32",
+            "lanes": "124,125,126,127",
+            "alias_at_lanes": "Eth32/1, Eth32/2, Eth32/3, Eth32/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        }
     }
 }

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -44,7 +44,6 @@ class TestCfgGenPlatformJson(TestCase):
     def test_platform_json_interfaces_keys(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -S "' + self.hwsku_json + '" -v "PORT.keys()"'
         output = self.run_script(argument)
-        print("kkkkkkk -> {}".format(output))
         expected = "['Ethernet8', 'Ethernet9', 'Ethernet36', 'Ethernet98', 'Ethernet0', 'Ethernet6', 'Ethernet4', 'Ethernet109', 'Ethernet108', 'Ethernet18', 'Ethernet100', 'Ethernet34', 'Ethernet104', 'Ethernet106', 'Ethernet94', 'Ethernet126', 'Ethernet96', 'Ethernet124', 'Ethernet90', 'Ethernet91', 'Ethernet92', 'Ethernet93', 'Ethernet50', 'Ethernet51', 'Ethernet52', 'Ethernet53', 'Ethernet54', 'Ethernet99', 'Ethernet56', 'Ethernet113', 'Ethernet76', 'Ethernet74', 'Ethernet39', 'Ethernet72', 'Ethernet73', 'Ethernet70', 'Ethernet71', 'Ethernet32', 'Ethernet33', 'Ethernet16', 'Ethernet111', 'Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13', 'Ethernet58', 'Ethernet19', 'Ethernet59', 'Ethernet38', 'Ethernet78', 'Ethernet68', 'Ethernet14', 'Ethernet89', 'Ethernet88', 'Ethernet118', 'Ethernet119', 'Ethernet116', 'Ethernet114', 'Ethernet80', 'Ethernet112', 'Ethernet86', 'Ethernet110', 'Ethernet84', 'Ethernet31', 'Ethernet49', 'Ethernet48', 'Ethernet46', 'Ethernet30', 'Ethernet29', 'Ethernet40', 'Ethernet120', 'Ethernet28', 'Ethernet66', 'Ethernet60', 'Ethernet64', 'Ethernet44', 'Ethernet20', 'Ethernet79', 'Ethernet69', 'Ethernet24', 'Ethernet26']"
         self.assertEqual(output.strip(), expected)
 

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -14,7 +14,7 @@ class TestCfgGenPlatformJson(TestCase):
         self.script_file = os.path.join(self.test_dir, '..', 'sonic-cfggen')
         self.sample_graph_simple = os.path.join(self.test_dir, 'simple-sample-graph.xml')
         self.platform_json = os.path.join(self.test_dir, 'sample_platform.json')
-
+        self.hwsku_json = os.path.join(self.test_dir, 'sample_hwsku.json')
 
     def run_script(self, argument, check_stderr=False):
         print '\n    Running sonic-cfggen ' + argument
@@ -42,27 +42,28 @@ class TestCfgGenPlatformJson(TestCase):
 
     # Check whether all interfaces present or not as per platform.json
     def test_platform_json_interfaces_keys(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -v "PORT.keys()"'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -S "' + self.hwsku_json + '" -v "PORT.keys()"'
         output = self.run_script(argument)
+        print("kkkkkkk -> {}".format(output))
         expected = "['Ethernet8', 'Ethernet9', 'Ethernet36', 'Ethernet98', 'Ethernet0', 'Ethernet6', 'Ethernet4', 'Ethernet109', 'Ethernet108', 'Ethernet18', 'Ethernet100', 'Ethernet34', 'Ethernet104', 'Ethernet106', 'Ethernet94', 'Ethernet126', 'Ethernet96', 'Ethernet124', 'Ethernet90', 'Ethernet91', 'Ethernet92', 'Ethernet93', 'Ethernet50', 'Ethernet51', 'Ethernet52', 'Ethernet53', 'Ethernet54', 'Ethernet99', 'Ethernet56', 'Ethernet113', 'Ethernet76', 'Ethernet74', 'Ethernet39', 'Ethernet72', 'Ethernet73', 'Ethernet70', 'Ethernet71', 'Ethernet32', 'Ethernet33', 'Ethernet16', 'Ethernet111', 'Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13', 'Ethernet58', 'Ethernet19', 'Ethernet59', 'Ethernet38', 'Ethernet78', 'Ethernet68', 'Ethernet14', 'Ethernet89', 'Ethernet88', 'Ethernet118', 'Ethernet119', 'Ethernet116', 'Ethernet114', 'Ethernet80', 'Ethernet112', 'Ethernet86', 'Ethernet110', 'Ethernet84', 'Ethernet31', 'Ethernet49', 'Ethernet48', 'Ethernet46', 'Ethernet30', 'Ethernet29', 'Ethernet40', 'Ethernet120', 'Ethernet28', 'Ethernet66', 'Ethernet60', 'Ethernet64', 'Ethernet44', 'Ethernet20', 'Ethernet79', 'Ethernet69', 'Ethernet24', 'Ethernet26']"
         self.assertEqual(output.strip(), expected)
 
     # Check specific Interface with it's proper configuration as per platform.json
     def test_platform_json_specific_ethernet_interfaces(self):
 
-        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -v "PORT[\'Ethernet8\']"'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -S "' + self.hwsku_json  + '" -v "PORT[\'Ethernet8\']"'
         output = self.run_script(argument)
         expected = "{'index': '3', 'lanes': '8', 'description': 'Eth3/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth3/1', 'pfc_asym': 'off', 'speed': '25000'}"
         self.assertEqual(output.strip(), expected)
 
-        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -v "PORT[\'Ethernet112\']"'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -S "' + self.hwsku_json  + '" -v "PORT[\'Ethernet112\']"'
         output = self.run_script(argument)
         expected = "{'index': '29', 'lanes': '112', 'description': 'Eth29/1', 'admin_status': 'up', 'mtu': '9100', 'alias': 'Eth29/1', 'pfc_asym': 'off', 'speed': '25000'}"
         self.assertEqual(output.strip(), expected)
 
     # Check all Interface with it's proper configuration as per platform.json
     def test_platform_json_all_ethernet_interfaces(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -v "PORT"'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -S "' + self.hwsku_json  + '" -v "PORT"'
         output = self.run_script(argument)
 
         sample_file = os.path.join(self.test_dir, 'sample_output', "platform_output.json")


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**
fixed **test_cfggen_platformJson.py**  test script as it was broken after introduction of **hwsku.json**

**- How I did it**

1. Added a sample **hwsku.json** file in **"src/sonic-config-engine/tests"** folder to use during test.
2. Added new option **"-S"/"--hwsku-config"** to **sonic-cfggen** as it is necessary to have some kind of default file during image build up especially for test cases to pass.
3. using new option **"-S"/"--hwsku-config"** to test file to get results.

**- How to verify it**
**sonic_config_engine-1.0-py2-none-any.whl** package got built successfully with all test cases passed.
```
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage$ BLDENV=stretch make target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
+++ --- Making target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl --- +++
EXTRA_JESSIE_TARGETS=sonic_config_engine-1.0-py2-none-any.whl make -f Makefile.work jessie
make[1]: Entering directory '/home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage'
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : "20200214.092507"
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"

make: Nothing to be done for 'jessie'.
make[1]: Leaving directory '/home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage'
BLDENV=stretch make -f Makefile.work target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
make[1]: Entering directory '/home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage'
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "24"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : "20200214.092514"
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"ENABLE_SFLOW"                    : "y"

make[1]: Leaving directory '/home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage'

```

```
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage$ ls -la target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
-rw-r--r-- 1 samaity samaity 45343 Feb 14 09:25 target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
```
