### PR TITLE
fix portconfig script

### DIFF
--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -45,7 +45,8 @@ class TestCfgGenPlatformJson(TestCase):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.platform_json + '" -S "' + self.hwsku_json + '" -v "PORT.keys()"'
         output = self.run_script(argument)
         expected = "['Ethernet8', 'Ethernet9', 'Ethernet36', 'Ethernet98', 'Ethernet0', 'Ethernet6', 'Ethernet4', 'Ethernet109', 'Ethernet108', 'Ethernet18', 'Ethernet100', 'Ethernet34', 'Ethernet104', 'Ethernet106', 'Ethernet94', 'Ethernet126', 'Ethernet96', 'Ethernet124', 'Ethernet90', 'Ethernet91', 'Ethernet92', 'Ethernet93', 'Ethernet50', 'Ethernet51', 'Ethernet52', 'Ethernet53', 'Ethernet54', 'Ethernet99', 'Ethernet56', 'Ethernet113', 'Ethernet76', 'Ethernet74', 'Ethernet39', 'Ethernet72', 'Ethernet73', 'Ethernet70', 'Ethernet71', 'Ethernet32', 'Ethernet33', 'Ethernet16', 'Ethernet111', 'Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13', 'Ethernet58', 'Ethernet19', 'Ethernet59', 'Ethernet38', 'Ethernet78', 'Ethernet68', 'Ethernet14', 'Ethernet89', 'Ethernet88', 'Ethernet118', 'Ethernet119', 'Ethernet116', 'Ethernet114', 'Ethernet80', 'Ethernet112', 'Ethernet86', 'Ethernet110', 'Ethernet84', 'Ethernet31', 'Ethernet49', 'Ethernet48', 'Ethernet46', 'Ethernet30', 'Ethernet29', 'Ethernet40', 'Ethernet120', 'Ethernet28', 'Ethernet66', 'Ethernet60', 'Ethernet64', 'Ethernet44', 'Ethernet20', 'Ethernet79', 'Ethernet69', 'Ethernet24', 'Ethernet26']"
-        self.assertEqual(output.strip(), expected)
+
+        self.assertEqual(sorted(output.strip()), sorted(expected))
 
     # Check specific Interface with it's proper configuration as per platform.json
     def test_platform_json_specific_ethernet_interfaces(self):


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
Removed duplicate code from **parse_platform_json_file**  as we introduced **get_child_ports** function for that. 

sorted the port list of **test_platform_json_interfaces_keys** test output so that order does not matter during the test so the test will pass easily.

**- How to verify it**

Built the sonic-image without any error.
```
admin@lnos-x1-a-fab01:~$ sonic-cfggen -k Seastone-DX010 --print-data
{
    "BREAKOUT_CFG": {
        "Ethernet0": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet4": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet8": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet12": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet16": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet20": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet24": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet28": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet32": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet36": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet40": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet44": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet48": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet52": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet56": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet60": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet64": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet68": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet72": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet76": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet80": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet84": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet88": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet92": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet96": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet100": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet104": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet108": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet112": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet116": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet120": {
            "brkout_mode": "1x100G[40G]"
        },
        "Ethernet124": {
            "brkout_mode": "1x100G[40G]"
        }
    },
    "DEVICE_METADATA": {
        "localhost": {
            "hwsku": "Seastone-DX010",
            "mac": "00:e0:ec:3c:09:96",
            "platform": "x86_64-cel_seastone-r0"
        }
    },
    "PORT": {
        "Ethernet0": {
            "admin_status": "up",
            "alias": "Eth1/1",
            "index": "1",
            "lanes": "65,66,67,68",
            "speed": "100000"
        },
        "Ethernet4": {
            "admin_status": "up",
            "alias": "Eth2/1",
            "index": "2",
            "lanes": "69,70,71,72",
            "speed": "100000"
        },
        "Ethernet8": {
            "admin_status": "up",
            "alias": "Eth3/1",
            "index": "3",
            "lanes": "73,74,75,76",
            "speed": "100000"
        },
        "Ethernet12": {
            "admin_status": "up",
            "alias": "Eth4/1",
            "index": "4",
            "lanes": "77,78,79,80",
            "speed": "100000"
        },
        "Ethernet16": {
            "admin_status": "up",
            "alias": "Eth5/1",
            "index": "5",
            "lanes": "33,34,35,36",
            "speed": "100000"
        },
        "Ethernet20": {
            "admin_status": "up",
            "alias": "Eth6/1",
            "index": "6",
            "lanes": "37,38,39,40",
            "speed": "100000"
        },
        "Ethernet24": {
            "admin_status": "up",
            "alias": "Eth7/1",
            "index": "7",
            "lanes": "41,42,43,44",
            "speed": "100000"
        },
        "Ethernet28": {
            "admin_status": "up",
            "alias": "Eth8/1",
            "index": "8",
            "lanes": "45,46,47,48",
            "speed": "100000"
        },
        "Ethernet32": {
            "admin_status": "up",
            "alias": "Eth9/1",
            "index": "9",
            "lanes": "49,50,51,52",
            "speed": "100000"
        },
        "Ethernet36": {
            "admin_status": "up",
            "alias": "Eth10/1",
            "index": "10",
            "lanes": "53,54,55,56",
            "speed": "100000"
        },
        "Ethernet40": {
            "admin_status": "up",
            "alias": "Eth11/1",
            "index": "11",
            "lanes": "57,58,59,60",
            "speed": "100000"
        },
        "Ethernet44": {
            "admin_status": "up",
            "alias": "Eth12/1",
            "index": "12",
            "lanes": "61,62,63,64",
            "speed": "100000"
        },
        "Ethernet48": {
            "admin_status": "up",
            "alias": "Eth13/1",
            "index": "13",
            "lanes": "81,82,83,84",
            "speed": "100000"
        },
        "Ethernet52": {
            "admin_status": "up",
            "alias": "Eth14/1",
            "index": "14",
            "lanes": "85,86,87,88",
            "speed": "100000"
        },
        "Ethernet56": {
            "admin_status": "up",
            "alias": "Eth15/1",
            "index": "15",
            "lanes": "89,90,91,92",
            "speed": "100000"
        },
        "Ethernet60": {
            "admin_status": "up",
            "alias": "Eth16/1",
            "index": "16",
            "lanes": "93,94,95,96",
            "speed": "100000"
        },
        "Ethernet64": {
            "admin_status": "up",
            "alias": "Eth17/1",
            "index": "17",
            "lanes": "97,98,99,100",
            "speed": "100000"
        },
        "Ethernet68": {
            "admin_status": "up",
            "alias": "Eth18/1",
            "index": "18",
            "lanes": "101,102,103,104",
            "speed": "100000"
        },
        "Ethernet72": {
            "admin_status": "up",
            "alias": "Eth19/1",
            "index": "19",
            "lanes": "105,106,107,108",
            "speed": "100000"
        },
        "Ethernet76": {
            "admin_status": "up",
            "alias": "Eth20/1",
            "index": "20",
            "lanes": "109,110,111,112",
            "speed": "100000"
        },
        "Ethernet80": {
            "admin_status": "up",
            "alias": "Eth21/1",
            "index": "21",
            "lanes": "1,2,3,4",
            "speed": "100000"
        },
        "Ethernet84": {
            "admin_status": "up",
            "alias": "Eth22/1",
            "index": "22",
            "lanes": "5,6,7,8",
            "speed": "100000"
        },
        "Ethernet88": {
            "admin_status": "up",
            "alias": "Eth23/1",
            "index": "23",
            "lanes": "9,10,11,12",
            "speed": "100000"
        },
        "Ethernet92": {
            "admin_status": "up",
            "alias": "Eth24/1",
            "index": "24",
            "lanes": "13,14,15,16",
            "speed": "100000"
        },
        "Ethernet96": {
            "admin_status": "up",
            "alias": "Eth25/1",
            "index": "25",
            "lanes": "17,18,19,20",
            "speed": "100000"
        },
        "Ethernet100": {
            "admin_status": "up",
            "alias": "Eth26/1",
            "index": "26",
            "lanes": "21,22,23,24",
            "speed": "100000"
        },
        "Ethernet104": {
            "admin_status": "up",
            "alias": "Eth27/1",
            "index": "27",
            "lanes": "25,26,27,28",
            "speed": "100000"
        },
        "Ethernet108": {
            "admin_status": "up",
            "alias": "Eth28/1",
            "index": "28",
            "lanes": "29,30,31,32",
            "speed": "100000"
        },
        "Ethernet112": {
            "admin_status": "up",
            "alias": "Eth29/1",
            "index": "29",
            "lanes": "113,114,115,116",
            "speed": "100000"
        },
        "Ethernet116": {
            "admin_status": "up",
            "alias": "Eth30/1",
            "index": "30",
            "lanes": "117,118,119,120",
            "speed": "100000"
        },
        "Ethernet120": {
            "admin_status": "up",
            "alias": "Eth31/1",
            "index": "31",
            "lanes": "121,122,123,124",
            "speed": "100000"
        },
        "Ethernet124": {
            "admin_status": "up",
            "alias": "Eth32/1",
            "index": "32",
            "lanes": "125,126,127,128",
            "speed": "100000"
        }
    }
}

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
