### PR TITLE
fix chassis plugin due to port index change for celestica device

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
@@ -56,7 +56,7 @@ class Chassis(ChassisBase):
         for index in range(0, NUM_THERMAL):
             thermal = Thermal(index)
             self._thermal_list.append(thermal)
-        for index in range(0, NUM_SFP):
+        for index in range(1, NUM_SFP+1):
             sfp = Sfp(index)
             self._sfp_list.append(sfp)
         for index in range(0, NUM_COMPONENT):


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**
Fixed  chassis plugin due to port index change for celestica device which will eventually fix `show in transceiver  eeprom` and `show in transceiver  presence` command

This PR is dependent on this [sonic-platform-common PR](https://github.com/zhenggen-xu/sonic-platform-common/pull/3)
**- How I did it**
Modified `port_index value` from 0 to 1 to fix the `xcvrd` daemon which will eventually post transceiver data to `STATE_DB`. 
**- How to verify it**

```
admin@lnos-x1-a-fab02:~$ show in transceiver  eeprom
Ethernet0: SFP EEPROM Not detected

Ethernet1: SFP EEPROM Not detected

Ethernet2: SFP EEPROM Not detected

Ethernet3: SFP EEPROM Not detected

Ethernet4: SFP EEPROM detected
        Connector: Copper pigtail
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP
        Length Cable Assembly(m): 2
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
                Gigabit Ethernet Compliant codes: 1000BASE-CX
        Vendor Date Code(YYYY-MM-DD Lot): 2011-09-10
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 112-00177
        Vendor Rev: A0
        Vendor SN: 125321000

Ethernet5: SFP EEPROM detected
        Connector: Copper pigtail
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP
        Length Cable Assembly(m): 2
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
                Gigabit Ethernet Compliant codes: 1000BASE-CX
        Vendor Date Code(YYYY-MM-DD Lot): 2011-09-10
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 112-00177
        Vendor Rev: A0
        Vendor SN: 125321000

Ethernet6: SFP EEPROM detected
        Connector: Copper pigtail
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP
        Length Cable Assembly(m): 2
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
                Gigabit Ethernet Compliant codes: 1000BASE-CX
        Vendor Date Code(YYYY-MM-DD Lot): 2011-09-10
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 112-00177
        Vendor Rev: A0
        Vendor SN: 125321000

Ethernet7: SFP EEPROM detected
        Connector: Copper pigtail
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP
        Length Cable Assembly(m): 2
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                Fibre Channel Speed: 1200 Mbytes/Sec
                Fibre Channel link length/Transmitter Technology: Electrical inter-enclosure (EL)
                Fibre Channel transmission media: Twin Axial Pair (TW)
                Gigabit Ethernet Compliant codes: 1000BASE-CX
        Vendor Date Code(YYYY-MM-DD Lot): 2011-09-10
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 112-00177
        Vendor Rev: A0
        Vendor SN: 125321000

Ethernet8: SFP EEPROM Not detected

Ethernet9: SFP EEPROM Not detected

Ethernet10: SFP EEPROM Not detected

Ethernet11: SFP EEPROM Not detected

Ethernet12: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 3
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                SAS/SATA compliance codes: SAS 3.0G
        Vendor Date Code(YYYY-MM-DD Lot): 2016-07-23
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1002971301
        Vendor Rev: 1
        Vendor SN: 620520056

Ethernet13: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 3
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                SAS/SATA compliance codes: SAS 3.0G
        Vendor Date Code(YYYY-MM-DD Lot): 2016-07-23
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1002971301
        Vendor Rev: 1
        Vendor SN: 620520056

Ethernet14: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 3
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                SAS/SATA compliance codes: SAS 3.0G
        Vendor Date Code(YYYY-MM-DD Lot): 2016-07-23
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1002971301
        Vendor Rev: 1
        Vendor SN: 620520056

Ethernet15: SFP EEPROM detected
        Connector: No separable connector
        Encoding: Unspecified
        Extended Identifier: Power Class 1(1.5W max)
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 3
        Nominal Bit Rate(100Mbs): 0
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                SAS/SATA compliance codes: SAS 3.0G
        Vendor Date Code(YYYY-MM-DD Lot): 2016-07-23
        Vendor Name: Molex Inc.
        Vendor OUI: 00-09-3a
        Vendor PN: 1002971301
        Vendor Rev: 1
        Vendor SN: 620520056

Ethernet16: SFP EEPROM Not detected

Ethernet17: SFP EEPROM Not detected

Ethernet18: SFP EEPROM Not detected

Ethernet19: SFP EEPROM Not detected

Ethernet20: SFP EEPROM Not detected

Ethernet21: SFP EEPROM Not detected

Ethernet22: SFP EEPROM Not detected

Ethernet23: SFP EEPROM Not detected

Ethernet24: SFP EEPROM Not detected

Ethernet25: SFP EEPROM Not detected

Ethernet26: SFP EEPROM Not detected

Ethernet27: SFP EEPROM Not detected

Ethernet28: SFP EEPROM Not detected

Ethernet29: SFP EEPROM Not detected

Ethernet30: SFP EEPROM Not detected

Ethernet31: SFP EEPROM Not detected

Ethernet32: SFP EEPROM Not detected

Ethernet33: SFP EEPROM Not detected

Ethernet34: SFP EEPROM Not detected

Ethernet35: SFP EEPROM Not detected

Ethernet36: SFP EEPROM Not detected

Ethernet37: SFP EEPROM Not detected

Ethernet38: SFP EEPROM Not detected

Ethernet39: SFP EEPROM Not detected

Ethernet40: SFP EEPROM Not detected

Ethernet41: SFP EEPROM Not detected

Ethernet42: SFP EEPROM Not detected

Ethernet43: SFP EEPROM Not detected

Ethernet44: SFP EEPROM Not detected

Ethernet45: SFP EEPROM Not detected

Ethernet46: SFP EEPROM Not detected

Ethernet47: SFP EEPROM Not detected

Ethernet48: SFP EEPROM Not detected

Ethernet49: SFP EEPROM Not detected

Ethernet50: SFP EEPROM Not detected

Ethernet51: SFP EEPROM Not detected

Ethernet52: SFP EEPROM Not detected

Ethernet53: SFP EEPROM Not detected

Ethernet54: SFP EEPROM Not detected

Ethernet55: SFP EEPROM Not detected

Ethernet56: SFP EEPROM Not detected

Ethernet57: SFP EEPROM Not detected

Ethernet58: SFP EEPROM Not detected

Ethernet59: SFP EEPROM Not detected

Ethernet60: SFP EEPROM Not detected

Ethernet61: SFP EEPROM Not detected

Ethernet62: SFP EEPROM Not detected

Ethernet63: SFP EEPROM Not detected

Ethernet64: SFP EEPROM Not detected

Ethernet65: SFP EEPROM Not detected

Ethernet66: SFP EEPROM Not detected

Ethernet67: SFP EEPROM Not detected

Ethernet68: SFP EEPROM Not detected

Ethernet69: SFP EEPROM Not detected

Ethernet70: SFP EEPROM Not detected

Ethernet71: SFP EEPROM Not detected

Ethernet72: SFP EEPROM Not detected

Ethernet73: SFP EEPROM Not detected

Ethernet74: SFP EEPROM Not detected

Ethernet75: SFP EEPROM Not detected

Ethernet76: SFP EEPROM Not detected

Ethernet77: SFP EEPROM Not detected

Ethernet78: SFP EEPROM Not detected

Ethernet79: SFP EEPROM Not detected

Ethernet80: SFP EEPROM Not detected

Ethernet81: SFP EEPROM Not detected

Ethernet82: SFP EEPROM Not detected

Ethernet83: SFP EEPROM Not detected

Ethernet84: SFP EEPROM Not detected

Ethernet85: SFP EEPROM Not detected

Ethernet86: SFP EEPROM Not detected

Ethernet87: SFP EEPROM Not detected

Ethernet88: SFP EEPROM Not detected

Ethernet89: SFP EEPROM Not detected

Ethernet90: SFP EEPROM Not detected

Ethernet91: SFP EEPROM Not detected

Ethernet92: SFP EEPROM Not detected

Ethernet93: SFP EEPROM Not detected

Ethernet94: SFP EEPROM Not detected

Ethernet95: SFP EEPROM Not detected

Ethernet96: SFP EEPROM Not detected

Ethernet98: SFP EEPROM Not detected

Ethernet100: SFP EEPROM Not detected

Ethernet102: SFP EEPROM Not detected

Ethernet104: SFP EEPROM Not detected

Ethernet106: SFP EEPROM Not detected

Ethernet108: SFP EEPROM Not detected

Ethernet110: SFP EEPROM Not detected

Ethernet112: SFP EEPROM Not detected

Ethernet114: SFP EEPROM Not detected

Ethernet116: SFP EEPROM Not detected

Ethernet118: SFP EEPROM Not detected

Ethernet120: SFP EEPROM Not detected

Ethernet122: SFP EEPROM Not detected

Ethernet124: SFP EEPROM Not detected

Ethernet126: SFP EEPROM Not detected

```
```
admin@lnos-x1-a-fab02:~$ show int transceiver presence
Port         Presence
-----------  -----------
Ethernet0    Not present
Ethernet1    Not present
Ethernet2    Not present
Ethernet3    Not present
Ethernet4    Present
Ethernet5    Present
Ethernet6    Present
Ethernet7    Present
Ethernet8    Not present
Ethernet9    Not present
Ethernet10   Not present
Ethernet11   Not present
Ethernet12   Present
Ethernet13   Present
Ethernet14   Present
Ethernet15   Present
Ethernet16   Not present
Ethernet17   Not present
Ethernet18   Not present
Ethernet19   Not present
Ethernet20   Not present
Ethernet21   Not present
Ethernet22   Not present
Ethernet23   Not present
Ethernet24   Not present
Ethernet25   Not present
Ethernet26   Not present
Ethernet27   Not present
Ethernet28   Not present
Ethernet29   Not present
Ethernet30   Not present
Ethernet31   Not present
Ethernet32   Not present
Ethernet33   Not present
Ethernet34   Not present
Ethernet35   Not present
Ethernet36   Not present
Ethernet37   Not present
Ethernet38   Not present
Ethernet39   Not present
Ethernet40   Not present
Ethernet41   Not present
Ethernet42   Not present
Ethernet43   Not present
Ethernet44   Not present
Ethernet45   Not present
Ethernet46   Not present
Ethernet47   Not present
Ethernet48   Not present
Ethernet49   Not present
Ethernet50   Not present
Ethernet51   Not present
Ethernet52   Not present
Ethernet53   Not present
Ethernet54   Not present
Ethernet55   Not present
Ethernet56   Not present
Ethernet57   Not present
Ethernet58   Not present
Ethernet59   Not present
Ethernet60   Not present
Ethernet61   Not present
Ethernet62   Not present
Ethernet63   Not present
Ethernet64   Not present
Ethernet65   Not present
Ethernet66   Not present
Ethernet67   Not present
Ethernet68   Not present
Ethernet69   Not present
Ethernet70   Not present
Ethernet71   Not present
Ethernet72   Not present
Ethernet73   Not present
Ethernet74   Not present
Ethernet75   Not present
Ethernet76   Not present
Ethernet77   Not present
Ethernet78   Not present
Ethernet79   Not present
Ethernet80   Not present
Ethernet81   Not present
Ethernet82   Not present
Ethernet83   Not present
Ethernet84   Not present
Ethernet85   Not present
Ethernet86   Not present
Ethernet87   Not present
Ethernet88   Not present
Ethernet89   Not present
Ethernet90   Not present
Ethernet91   Not present
Ethernet92   Not present
Ethernet93   Not present
Ethernet94   Not present
Ethernet95   Not present
Ethernet96   Not present
Ethernet98   Not present
Ethernet100  Not present
Ethernet102  Not present
Ethernet104  Not present
Ethernet106  Not present
Ethernet108  Not present
Ethernet110  Not present
Ethernet112  Not present
Ethernet114  Not present
Ethernet116  Not present
Ethernet118  Not present
Ethernet120  Not present
Ethernet122  Not present
Ethernet124  Not present
Ethernet126  Not present
admin@lnos-x1-a-fab02:~$
```
```
admin@lnos-x1-a-fab02:~$ show int transceiver lpmode
Port         Low-power Mode
-----------  ----------------
Ethernet0    Off
Ethernet1    Off
Ethernet2    Off
Ethernet3    Off
Ethernet4    Off
Ethernet5    Off
Ethernet6    Off
Ethernet7    Off
Ethernet8    Off
Ethernet9    Off
Ethernet10   Off
Ethernet11   Off
Ethernet12   Off
Ethernet13   Off
Ethernet14   Off
Ethernet15   Off
Ethernet16   Off
Ethernet17   Off
Ethernet18   Off
Ethernet19   Off
Ethernet20   Off
Ethernet21   Off
Ethernet22   Off
Ethernet23   Off
Ethernet24   Off
Ethernet25   Off
Ethernet26   Off
Ethernet27   Off
Ethernet28   Off
Ethernet29   Off
Ethernet30   Off
Ethernet31   Off
Ethernet32   Off
Ethernet33   Off
Ethernet34   Off
Ethernet35   Off
Ethernet36   Off
Ethernet37   Off
Ethernet38   Off
Ethernet39   Off
Ethernet40   Off
Ethernet41   Off
Ethernet42   Off
Ethernet43   Off
Ethernet44   Off
Ethernet45   Off
Ethernet46   Off
Ethernet47   Off
Ethernet48   Off
Ethernet49   Off
Ethernet50   Off
Ethernet51   Off
Ethernet52   Off
Ethernet53   Off
Ethernet54   Off
Ethernet55   Off
Ethernet56   Off
Ethernet57   Off
Ethernet58   Off
Ethernet59   Off
Ethernet60   Off
Ethernet61   Off
Ethernet62   Off
Ethernet63   Off
Ethernet64   Off
Ethernet65   Off
Ethernet66   Off
Ethernet67   Off
Ethernet68   Off
Ethernet69   Off
Ethernet70   Off
Ethernet71   Off
Ethernet72   Off
Ethernet73   Off
Ethernet74   Off
Ethernet75   Off
Ethernet76   Off
Ethernet77   Off
Ethernet78   Off
Ethernet79   Off
Ethernet80   Off
Ethernet81   Off
Ethernet82   Off
Ethernet83   Off
Ethernet84   Off
Ethernet85   Off
Ethernet86   Off
Ethernet87   Off
Ethernet88   Off
Ethernet89   Off
Ethernet90   Off
Ethernet91   Off
Ethernet92   Off
Ethernet93   Off
Ethernet94   Off
Ethernet95   Off
Ethernet96   Off
Ethernet98   Off
Ethernet100  Off
Ethernet102  Off
Ethernet104  Off
Ethernet106  Off
Ethernet108  Off
Ethernet110  Off
Ethernet112  Off
Ethernet114  Off
Ethernet116  Off
Ethernet118  Off
Ethernet120  Off
Ethernet122  Off
Ethernet124  Off
Ethernet126  Off
```