### PR TITLE
Vs start.sh script fix

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -128,6 +128,7 @@ COPY ["files/sonic_version.yml", "/etc/sonic/"]
 COPY ["database_config.json", "/etc/default/sonic-db/"]
 COPY ["platform.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/"]
 COPY ["hwsku.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/"]
+COPY ["platform.json", "/usr/share/sonic/platform/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/platform.json
+++ b/platform/vs/docker-sonic-vs/platform.json
@@ -3,193 +3,193 @@
         "Ethernet0": {
             "index": "0,0,0,0",
             "lanes": "25,26,27,28",
-            "alias_at_lanes": "Eth0/1,Eth0/2,Eth0/3,Eth0/4",
+            "alias_at_lanes": "fortyGig0/0,fortyGig0/1,fortyGig0/2,fortyGig0/3",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
        "Ethernet4": {
             "index": "1,1,1,1",
             "lanes": "29,30,31,32",
-            "alias_at_lanes": "Eth1/1,Eth1/2,Eth1/3,Eth1/4",
+            "alias_at_lanes": "fortyGig0/4,fortyGig0/5,fortyGig0/6,fortyGig0/7",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
         },
         "Ethernet8": {
             "index": "2,2,2,2",
             "lanes": "33,34,35,36",
-            "alias_at_lanes": "Eth2/1,Eth2/2,Eth2/3,Eth2/4",
+            "alias_at_lanes": "fortyGig0/8,fortyGig0/9,fortyGig0/10,fortyGig0/11",
             "breakout_modes": "1x100G[40G],2x50G,2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet12": {
             "index": "3,3,3,3",
             "lanes": "37,38,39,40",
-            "alias_at_lanes": "Eth3/1,Eth3/2,Eth3/3,Eth3/4",
+            "alias_at_lanes": "fortyGig0/12,fortyGig0/13,fortyGig0/14,fortyGig0/15",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet16": {
             "index": "4,4,4,4",
             "lanes": "45,46,47,48",
-            "alias_at_lanes": "Eth4/1,Eth4/2,Eth4/3,Eth4/4",
+            "alias_at_lanes": "fortyGig0/16,fortyGig0/17,fortyGig0/18,fortyGig0/19",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet20": {
             "index": "5,5,5,5",
             "lanes": "41,42,43,44",
-            "alias_at_lanes": "Eth5/1,Eth5/2,Eth5/3,Eth5/4",
+            "alias_at_lanes": "fortyGig0/20,fortyGig0/21,fortyGig0/22,fortyGig0/23",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet24": {
             "index": "6,6,6,6",
             "lanes": "1,2,3,4",
-            "alias_at_lanes": "Eth6/1,Eth6/2,Eth6/3,Eth6/4",
+            "alias_at_lanes": "fortyGig0/24,fortyGig0/25,fortyGig0/26,fortyGig0/27",
             "breakout_modes": "1x100G[40G],4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet28": {
             "index": "7,7,7,7",
             "lanes": "5,6,7,8",
-            "alias_at_lanes": "Eth7/1,Eth7/2,Eth7/3,Eth7/4",
+            "alias_at_lanes": "fortyGig0/28,fortyGig0/29,fortyGig0/30,fortyGig0/31",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet32": {
             "index": "8,8,8,8",
             "lanes": "13,14,15,16",
-            "alias_at_lanes": "Eth8/1,Eth8/2,Eth8/3,Eth8/4",
+            "alias_at_lanes": "fortyGig0/32,fortyGig0/33,fortyGig0/34,fortyGig0/35",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet36": {
             "index": "9,9,9,9",
             "lanes": "9,10,11,12",
-            "alias_at_lanes": "Eth9/1,Eth9/2,Eth9/3,Eth9/4",
+            "alias_at_lanes": "fortyGig0/36,fortyGig0/37,fortyGig0/38,fortyGig0/39",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet40": {
             "index": "10,10,10,10",
             "lanes": "17,18,19,20",
-            "alias_at_lanes": "Eth10/1,Eth10/2,Eth10/3,Eth10/4",
+            "alias_at_lanes": "fortyGig0/40,fortyGig0/41,fortyGig0/42,fortyGig0/43",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet44": {
             "index": "11,11,11,11",
             "lanes": "21,22,23,24",
-            "alias_at_lanes": "Eth11/1,Eth11/2,Eth11/3,Eth11/4",
+            "alias_at_lanes": "fortyGig0/44,fortyGig0/45,fortyGig0/46,fortyGig0/47",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet48": {
             "index": "12,12,12,12",
             "lanes": "53,54,55,56",
-            "alias_at_lanes": "Eth12/1,Eth12/2,Eth12/3,Eth12/4",
+            "alias_at_lanes": "fortyGig0/48,fortyGig0/49,fortyGig0/50,fortyGig0/51",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet52": {
             "index": "13,13,13,13",
             "lanes": "49,50,51,52",
-            "alias_at_lanes": "Eth13/1,Eth13/2,Eth13/3,Eth13/4",
+            "alias_at_lanes": "fortyGig0/52,fortyGig0/53,fortyGig0/54,fortyGig0/55",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet56": {
             "index": "14,14,14,14",
             "lanes": "57,58,59,60",
-            "alias_at_lanes": "Eth14/1,Eth14/2,Eth14/3,Eth14/4",
+            "alias_at_lanes": "fortyGig0/56,fortyGig0/57,fortyGig0/58,fortyGig0/59",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet60": {
             "index": "15,15,15,15",
             "lanes": "61,62,63,64",
-            "alias_at_lanes": "Eth15/1,Eth15/2,Eth15/3,Eth15/4",
+            "alias_at_lanes": "fortyGig0/60,fortyGig0/61,fortyGig0/62,fortyGig0/63",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet64": {
             "index": "16,16,16,16",
             "lanes": "69,70,71,72",
-            "alias_at_lanes": "Eth16/1,Eth16/2,Eth16/3,Eth16/4",
+            "alias_at_lanes": "fortyGig0/64,fortyGig0/65,fortyGig0/66,fortyGig0/67",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet68": {
             "index": "17,17,17,17",
             "lanes": "65,66,67,68",
-            "alias_at_lanes": "Eth17/1,Eth17/2,Eth17/3,Eth17/4",
+            "alias_at_lanes": "fortyGig0/68,fortyGig0/69,fortyGig0/70,fortyGig0/71",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet72": {
             "index": "18,18,18,18",
             "lanes": "73,74,75,76",
-            "alias_at_lanes": "Eth18/1,Eth18/2,Eth18/3,Eth18/4",
+            "alias_at_lanes": "fortyGig0/72,fortyGig0/73,fortyGig0/74,fortyGig0/75",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet76": {
             "index": "19,19,19,19",
             "lanes": "77,78,79,80",
-            "alias_at_lanes": "Eth19/1,Eth19/2,Eth19/3,Eth19/4",
+            "alias_at_lanes": "fortyGig0/76,fortyGig0/77,fortyGig0/78,fortyGig0/79",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet80": {
             "index": "20,20,20,20",
             "lanes": "109,110,111,112",
-            "alias_at_lanes": "Eth20/1,Eth20/2,Eth20/3,Eth20/4",
+            "alias_at_lanes": "fortyGig0/80,fortyGig0/81,fortyGig0/82,fortyGig0/83",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet84": {
             "index": "21,21,21,21",
             "lanes": "105,106,107,108",
-            "alias_at_lanes": "Eth21/1,Eth21/2,Eth21/3,Eth21/4",
+            "alias_at_lanes": "fortyGig0/84,fortyGig0/85,fortyGig0/86,fortyGig0/87",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet88": {
             "index": "22,22,22,22",
             "lanes": "113,114,115,116",
-            "alias_at_lanes": "Eth22/1,Eth22/2,Eth22/3,Eth22/4",
+            "alias_at_lanes": "fortyGig0/88,fortyGig0/89,fortyGig0/90,fortyGig0/91",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet92": {
             "index": "23,23,23,23",
             "lanes": "117,118,119,120",
-            "alias_at_lanes": "Eth23/1,Eth23/2,Eth23/3,Eth23/4",
+            "alias_at_lanes": "fortyGig0/92,fortyGig0/93,fortyGig0/94,fortyGig0/95",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet96": {
             "index": "24,24,24,24",
             "lanes": "125,126,127,128",
-            "alias_at_lanes": "Eth24/1,Eth24/2,Eth24/3,Eth24/4",
+            "alias_at_lanes": "fortyGig0/96,fortyGig0/97,fortyGig0/98,fortyGig0/99",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet100": {
             "index": "25,25,25,25",
             "lanes": "121,122,123,124",
-            "alias_at_lanes": "Eth25/1,Eth25/2,Eth25/3,Eth25/4",
+            "alias_at_lanes": "fortyGig0/100,fortyGig0/101,fortyGig0/102,fortyGig0/103",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet104": {
             "index": "26,26,26,26",
             "lanes": "81,82,83,84",
-            "alias_at_lanes": "Eth26/1,Eth26/2,Eth26/3,Eth26/4",
+            "alias_at_lanes": "fortyGig0/104,fortyGig0/105,fortyGig0/106,fortyGig0/107",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet108": {
             "index": "27,27,27,27",
             "lanes": "85,86,87,88",
-            "alias_at_lanes": "Eth27/1,Eth27/2,Eth27/3,Eth27/4",
+            "alias_at_lanes": "fortyGig0/108,fortyGig0/109,fortyGig0/110,fortyGig0/111",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet112": {
             "index": "28,28,28,28",
             "lanes": "93,94,95,96",
-            "alias_at_lanes": "Eth28/1,Eth28/2,Eth28/3,Eth28/4",
+            "alias_at_lanes": "fortyGig0/112,fortyGig0/113,fortyGig0/114,fortyGig0/115",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet116": {
             "index": "29,29,29,29",
             "lanes": "89,90,91,92",
-            "alias_at_lanes": "Eth29/1,Eth29/2,Eth29/3,Eth29/4",
+            "alias_at_lanes": "fortyGig0/116,fortyGig0/117,fortyGig0/118,fortyGig0/119",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet120": {
             "index": "30,30,30,30",
             "lanes": "101,102,103,104",
-            "alias_at_lanes": "Eth30/1,Eth30/2,Eth30/3,Eth30/4",
+            "alias_at_lanes": "fortyGig0/120,fortyGig0/121,fortyGig0/122,fortyGig0/123",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         },
         "Ethernet124": {
             "index": "31,31,31,31",
             "lanes": "97,98,99,100",
-            "alias_at_lanes": "Eth31/1,Eth31/2,Eth31/3,Eth31/4",
+            "alias_at_lanes": "fortyGig0/124,fortyGig0/125,fortyGig0/126,fortyGig0/127",
             "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
         }
     }

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -19,7 +19,7 @@ else
     # generate and merge buffers configuration into config file
     sonic-cfggen -t /usr/share/sonic/hwsku/buffers.json.j2 > /tmp/buffers.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -t /usr/share/sonic/hwsku/qos.json.j2 > /tmp/qos.json
-    sonic-cfggen -p /usr/share/sonic/hwsku/port_config.ini -k $HWSKU --print-data > /tmp/ports.json
+    sonic-cfggen -p /usr/share/sonic/device/$PLATFORM/platform.json -k $HWSKU --print-data > /tmp/ports.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/buffers.json -j /tmp/qos.json -j /tmp/ports.json --print-data > /etc/sonic/config_db.json
 fi
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>


**- What I did**
Vs docker is now compatible with platform.json file. It is the only port configuration file , the docker counts from now on.


**- How to verify it**
```
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -v --dvsname=vs-sang test_port_config.py
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests
plugins: repeat-0.8.0
collected 2 items

test_port_config.py::TestPortConfig::test_port_hw_lane PASSED                                                                                                [ 50%]
test_port_config.py::TestPortConfig::test_port_breakout PASSED                                                                                               [100%]

==================================================================== 2 passed in 70.61 seconds =====================================================================
```
```
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -v --dvsname=vs-sang test_acl.py
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests
plugins: repeat-0.8.0
collected 24 items

test_acl.py::TestAcl::test_AclTableCreation PASSED                                                                                                           [  4%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                                                                                                           [  8%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                                                                                                          [ 12%]
test_acl.py::TestAcl::test_AclRuleInPortsNonExistingInterface PASSED                                                                                         [ 16%]
test_acl.py::TestAcl::test_AclRuleOutPortsNonExistingInterface PASSED                                                                                        [ 20%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                                                                                                           [ 25%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                                                                                                         [ 29%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                                                                                                           [ 33%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                                                                                                       [ 37%]
test_acl.py::TestAcl::test_V6AclRuleIpProtocol PASSED                                                                                                        [ 41%]
test_acl.py::TestAcl::test_V6AclRuleSrcIPv6 PASSED                                                                                                           [ 45%]
test_acl.py::TestAcl::test_V6AclRuleDstIPv6 PASSED                                                                                                           [ 50%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPort PASSED                                                                                                         [ 54%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPort PASSED                                                                                                         [ 58%]
test_acl.py::TestAcl::test_V6AclRuleTCPFlags PASSED                                                                                                          [ 62%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPortRange PASSED                                                                                                    [ 66%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPortRange PASSED                                                                                                    [ 70%]
test_acl.py::TestAcl::test_V6AclTableDeletion PASSED                                                                                                         [ 75%]
test_acl.py::TestAcl::test_InsertAclRuleBetweenPriorities PASSED                                                                                             [ 79%]
test_acl.py::TestAcl::test_RulesWithDiffMaskLengths PASSED                                                                                                   [ 83%]
test_acl.py::TestAcl::test_AclRuleIcmp PASSED                                                                                                                [ 87%]
test_acl.py::TestAcl::test_AclRuleIcmpV6 PASSED                                                                                                              [ 91%]
test_acl.py::TestAcl::test_AclRuleRedirectToNexthop PASSED                                                                                                   [ 95%]
test_acl.py::TestAclRuleValidation::test_AclActionValidation PASSED                                                                                          [100%]

=================================================================== 24 passed in 220.83 seconds ========
```
```
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -v --dvsname=vs-sang test_vlan.py
[sudo] password for samaity:
================================================================================================================== test session starts ===================================================================================================================
platform linux2 -- Python 2.7.15+, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests
plugins: repeat-0.8.0
collected 25 items

test_vlan.py::TestVlan::test_VlanAddRemove PASSED                                                                                                                                                                                                  [  4%]
test_vlan.py::TestVlan::test_MultipleVlan PASSED                                                                                                                                                                                                   [  8%]
test_vlan.py::TestVlan::test_VlanIncrementalConfig PASSED                                                                                                                                                                                          [ 12%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input0-0] PASSED                                                                                                                                                                   [ 16%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input1-0] PASSED                                                                                                                                                                   [ 20%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input2-0] PASSED                                                                                                                                                                   [ 24%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input3-1] PASSED                                                                                                                                                                   [ 28%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input0-0] PASSED                                                                                                                                                                   [ 32%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input1-0] PASSED                                                                                                                                                                   [ 36%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input2-0] PASSED                                                                                                                                                                   [ 40%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input3-1] PASSED                                                                                                                                                                   [ 44%]
test_vlan.py::TestVlan::test_AddPortChannelToVlan PASSED                                                                                                                                                                                           [ 48%]
test_vlan.py::TestVlan::test_AddVlanMemberWithNonExistVlan PASSED                                                                                                                                                                                  [ 52%]
test_vlan.py::TestVlan::test_RemoveNonexistentVlan PASSED                                                                                                                                                                                          [ 56%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input0-expected0] PASSED                                                                                                                                                                   [ 60%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input1-expected1] PASSED                                                                                                                                                                   [ 64%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input2-expected2] PASSED                                                                                                                                                                   [ 68%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input3-expected3] PASSED                                                                                                                                                                   [ 72%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input4-expected4] PASSED                                                                                                                                                                   [ 76%]
test_vlan.py::TestVlan::test_AddMaxVlan SKIPPED                                                                                                                                                                                                    [ 80%]
test_vlan.py::TestVlan::test_RemoveVlanWithRouterInterface PASSED                                                                                                                                                                                  [ 84%]
test_vlan.py::TestVlan::test_VlanDbData PASSED                                                                                                                                                                                                     [ 88%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input0-expected0] PASSED                                                                                                                                                                        [ 92%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input1-expected1] PASSED                                                                                                                                                                        [ 96%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input2-expected2] PASSED                                                                                                                                                                        [100%]

========================================================================================================= 24 passed, 1 skipped in 140.83 seconds =========================================================================================================
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests$
```
```
============================= test session starts ==============================
platform linux2 -- Python 2.7.15+, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/src/sonic-swss/tests
plugins: repeat-0.8.0
collecting ... collected 248 items

test_acl.py::TestAcl::test_AclTableCreation PASSED                       [  0%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                       [  0%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                      [  1%]
test_acl.py::TestAcl::test_AclRuleInPortsNonExistingInterface PASSED     [  1%]
test_acl.py::TestAcl::test_AclRuleOutPortsNonExistingInterface PASSED    [  2%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                       [  2%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                     [  2%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                       [  3%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                   [  3%]
test_acl.py::TestAcl::test_V6AclRuleIpProtocol PASSED                    [  4%]
test_acl.py::TestAcl::test_V6AclRuleSrcIPv6 PASSED                       [  4%]
test_acl.py::TestAcl::test_V6AclRuleDstIPv6 PASSED                       [  4%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPort PASSED                     [  5%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPort PASSED                     [  5%]
test_acl.py::TestAcl::test_V6AclRuleTCPFlags PASSED                      [  6%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPortRange PASSED                [  6%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPortRange PASSED                [  6%]
test_acl.py::TestAcl::test_V6AclTableDeletion PASSED                     [  7%]
test_acl.py::TestAcl::test_InsertAclRuleBetweenPriorities PASSED         [  7%]
test_acl.py::TestAcl::test_RulesWithDiffMaskLengths PASSED               [  8%]
test_acl.py::TestAcl::test_AclRuleIcmp PASSED                            [  8%]
test_acl.py::TestAcl::test_AclRuleIcmpV6 PASSED                          [  8%]
test_acl.py::TestAcl::test_AclRuleRedirectToNexthop PASSED               [  9%]
test_acl.py::TestAclRuleValidation::test_AclActionValidation PASSED      [  9%]
test_acl_ctrl.py::TestPortChannelAcl::test_AclCtrl PASSED                [ 10%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclTableCreation PASSED [ 10%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleL4SrcPortRange PASSED [ 10%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleL4DstPortRange PASSED [ 11%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleL2EthType PASSED [ 11%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleTunnelVNI PASSED [ 12%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclRuleTC PASSED [ 12%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerIPProtocol PASSED [ 12%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerEthType PASSED [ 13%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerL4SrcPort PASSED [ 13%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclInnerL4DstPort PASSED [ 14%]
test_acl_egress_table.py::TestEgressAclTable::test_EgressAclTableDeletion PASSED [ 14%]
test_acl_portchannel.py::TestPortChannelAcl::test_PortChannelAfterAcl PASSED [ 14%]
test_acl_portchannel.py::TestPortChannelAcl::test_PortChannelBeforeAcl PASSED [ 15%]
test_acl_portchannel.py::TestPortChannelAcl::test_AclOnPortChannelMember PASSED [ 15%]
test_admin_status.py::TestAdminStatus::test_PortChannelMemberAdminStatus PASSED [ 16%]
test_crm.py::TestCrm::test_CrmFdbEntry PASSED                            [ 16%]
test_crm.py::TestCrm::test_CrmIpv4Route PASSED                           [ 16%]
test_crm.py::TestCrm::test_CrmIpv6Route PASSED                           [ 17%]
test_crm.py::TestCrm::test_CrmIpv4Nexthop PASSED                         [ 17%]
test_crm.py::TestCrm::test_CrmIpv6Nexthop PASSED                         [ 18%]
test_crm.py::TestCrm::test_CrmIpv4Neighbor PASSED                        [ 18%]
test_crm.py::TestCrm::test_CrmIpv6Neighbor PASSED                        [ 18%]
test_crm.py::TestCrm::test_CrmNexthopGroup PASSED                        [ 19%]
test_crm.py::TestCrm::test_CrmNexthopGroupMember PASSED                  [ 19%]
test_crm.py::TestCrm::test_CrmAcl PASSED                                 [ 20%]
test_crm.py::TestCrm::test_CrmAclGroup PASSED                            [ 20%]
test_crm.py::TestCrm::test_Configure PASSED                              [ 20%]
test_crm.py::TestCrm::test_Configure_ipv4_route PASSED                   [ 21%]
test_crm.py::TestCrm::test_Configure_ipv6_route PASSED                   [ 21%]
test_crm.py::TestCrm::test_Configure_ipv4_nexthop PASSED                 [ 22%]
test_crm.py::TestCrm::test_Configure_ipv6_nexthop PASSED                 [ 22%]
test_crm.py::TestCrm::test_Configure_ipv4_neighbor PASSED                [ 22%]
test_crm.py::TestCrm::test_Configure_ipv6_neighbor PASSED                [ 23%]
test_crm.py::TestCrm::test_Configure_group_member PASSED                 [ 23%]
test_crm.py::TestCrm::test_Configure_group_object PASSED                 [ 24%]
test_crm.py::TestCrm::test_Configure_acl_table PASSED                    [ 24%]
test_crm.py::TestCrm::test_Configure_acl_group PASSED                    [ 25%]
test_crm.py::TestCrm::test_Configure_acl_group_entry PASSED              [ 25%]
test_crm.py::TestCrm::test_Configure_acl_group_counter PASSED            [ 25%]
test_crm.py::TestCrm::test_Configure_fdb PASSED                          [ 26%]
test_dirbcast.py::TestDirectedBroadcast::test_DirectedBroadcast PASSED   [ 26%]
test_drop_counters.py::TestDropCounters::test_deviceCapabilitiesTablePopulated PASSED [ 27%]
test_drop_counters.py::TestDropCounters::test_flexCounterGroupInitialized PASSED [ 27%]
test_drop_counters.py::TestDropCounters::test_createAndRemoveDropCounterBasic PASSED [ 27%]
test_drop_counters.py::TestDropCounters::test_createAndRemoveDropCounterReversed PASSED [ 28%]
test_drop_counters.py::TestDropCounters::test_createCounterWithInvalidCounterType PASSED [ 28%]
test_drop_counters.py::TestDropCounters::test_createCounterWithInvalidDropReason PASSED [ 29%]
test_drop_counters.py::TestDropCounters::test_addReasonToInitializedCounter PASSED [ 29%]
test_drop_counters.py::TestDropCounters::test_removeReasonFromInitializedCounter PASSED [ 29%]
test_drop_counters.py::TestDropCounters::test_removeAllDropReasons PASSED [ 30%]
test_drop_counters.py::TestDropCounters::test_addDropReasonMultipleTimes PASSED [ 30%]
test_drop_counters.py::TestDropCounters::test_addInvalidDropReason PASSED [ 31%]
test_drop_counters.py::TestDropCounters::test_removeDropReasonMultipleTimes PASSED [ 31%]
test_drop_counters.py::TestDropCounters::test_removeNonexistentDropReason PASSED [ 31%]
test_drop_counters.py::TestDropCounters::test_removeInvalidDropReason PASSED [ 32%]
test_drop_counters.py::TestDropCounters::test_createAndDeleteMultipleCounters PASSED [ 32%]
test_dtel.py::TestDtel::test_DtelGlobalAttribs PASSED                    [ 33%]
test_dtel.py::TestDtel::test_DtelReportSessionAttribs PASSED             [ 33%]
test_dtel.py::TestDtel::test_DtelINTSessionAttribs PASSED                [ 33%]
test_dtel.py::TestDtel::test_DtelQueueReportAttribs PASSED               [ 34%]
test_dtel.py::TestDtel::test_DtelEventAttribs PASSED                     [ 34%]
test_fdb.py::TestFdb::test_FdbWarmRestartNotifications FAILED            [ 35%]
test_fdb.py::TestFdb::test_FdbAddedAfterMemberCreated PASSED             [ 35%]
test_fdb_update.py::test_FDBAddedAndUpdated PASSED                       [ 35%]
test_fdb_update.py::test_FDBLearnedAndUpdated PASSED                     [ 36%]
test_fdb_update.py::test_FDBLearnedAndFlushed PASSED                     [ 36%]
test_interface.py::TestRouterInterface::test_PortInterfaceAddRemoveIpv6Address PASSED [ 37%]
test_interface.py::TestRouterInterface::test_PortInterfaceAddRemoveIpv4Address PASSED [ 37%]
test_interface.py::TestRouterInterface::test_PortInterfaceSetMtu PASSED  [ 37%]
test_interface.py::TestRouterInterface::test_PortInterfaceAddRemoveIpv6AddressWithVrf PASSED [ 38%]
test_interface.py::TestRouterInterface::test_PortInterfaceAddRemoveIpv4AddressWithVrf PASSED [ 38%]
test_interface.py::TestRouterInterface::test_PortInterfaceAddSameIpv4AddressWithDiffVrf FAILED [ 39%]
test_interface.py::TestRouterInterface::test_LagInterfaceAddRemoveIpv6Address FAILED [ 39%]
test_interface.py::TestRouterInterface::test_LagInterfaceAddRemoveIpv4Address FAILED [ 39%]
test_interface.py::TestRouterInterface::test_LagInterfaceSetMtu FAILED   [ 40%]
test_interface.py::TestRouterInterface::test_LagInterfaceAddRemoveIpv6AddressWithVrf FAILED [ 40%]
test_interface.py::TestRouterInterface::test_LagInterfaceAddRemoveIpv4AddressWithVrf FAILED [ 41%]
test_interface.py::TestRouterInterface::test_VLanInterfaceAddRemoveIpv6Address FAILED [ 41%]
test_interface.py::TestRouterInterface::test_VLanInterfaceAddRemoveIpv4Address FAILED [ 41%]
test_interface.py::TestRouterInterface::test_VLanInterfaceAddRemoveIpv6AddressWithVrf FAILED [ 42%]
test_interface.py::TestRouterInterface::test_VLanInterfaceAddRemoveIpv4AddressWithVrf FAILED [ 42%]
test_interface.py::TestRouterInterface::test_LoopbackInterfacesAddRemoveIpv4Address PASSED [ 43%]
test_interface.py::TestRouterInterface::test_LoopbackInterfacesAddRemoveIpv6Address FAILED [ 43%]
test_interface.py::TestRouterInterface::test_LoopbackInterfaceIpv4AddressWithVrf FAILED [ 43%]
test_mirror.py::TestMirror::test_MirrorAddRemove PASSED                  [ 44%]
test_mirror.py::TestMirror::test_MirrorToVlanAddRemove PASSED            [ 44%]
test_mirror.py::TestMirror::test_MirrorToLagAddRemove PASSED             [ 45%]
test_mirror.py::TestMirror::test_MirrorDestMoveVlan PASSED               [ 45%]
test_mirror.py::TestMirror::test_MirrorDestMoveLag PASSED                [ 45%]
test_mirror.py::TestMirror::test_AclBindMirrorPerStage PASSED            [ 46%]
test_mirror.py::TestMirror::test_AclBindMirror PASSED                    [ 46%]
test_mirror_ipv6_combined.py::TestMirror::test_CombinedMirrorTableCreation FAILED [ 47%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6Combined FAILED [ 47%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6Reorder1 FAILED [ 47%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6Reorder2 FAILED [ 48%]
test_mirror_ipv6_combined.py::TestMirror::test_AclBindMirrorV6WrongConfig FAILED [ 48%]
test_mirror_ipv6_separate.py::TestMirror::test_MirrorTableCreation PASSED [ 49%]
test_mirror_ipv6_separate.py::TestMirror::test_MirrorV6TableCreation FAILED [ 49%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorSeparated FAILED [ 50%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6Reorder1 FAILED [ 50%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6Reorder2 FAILED [ 50%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6WrongConfig FAILED [ 51%]
test_mirror_policer.py::TestMirror::test_MirrorPolicer PASSED            [ 51%]
test_mirror_policer.py::TestMirror::test_MirrorPolicerWithAcl PASSED     [ 52%]
test_nat.py::TestNatFeature::test_NatGlobalTable PASSED                  [ 52%]
test_nat.py::TestNatFeature::test_NatInterfaceZone PASSED                [ 52%]
test_nat.py::TestNatFeature::test_AddNatStaticEntry PASSED               [ 53%]
test_nat.py::TestNatFeature::test_DelNatStaticEntry PASSED               [ 53%]
test_nat.py::TestNatFeature::test_AddNaPtStaticEntry PASSED              [ 54%]
test_nat.py::TestNatFeature::test_DelNaPtStaticEntry PASSED              [ 54%]
test_nat.py::TestNatFeature::test_AddTwiceNatEntry PASSED                [ 54%]
test_nat.py::TestNatFeature::test_DelTwiceNatStaticEntry PASSED          [ 55%]
test_nat.py::TestNatFeature::test_AddTwiceNaPtEntry PASSED               [ 55%]
test_nat.py::TestNatFeature::test_DelTwiceNaPtStaticEntry PASSED         [ 56%]
test_neighbor.py::TestNeighbor::test_NeighborAddRemoveIpv6 PASSED        [ 56%]
test_neighbor.py::TestNeighbor::test_NeighborAddRemoveIpv4 PASSED        [ 56%]
test_neighbor.py::TestNeighbor::test_NeighborAddRemoveIpv6WithVrf PASSED [ 57%]
test_neighbor.py::TestNeighbor::test_NeighborAddRemoveIpv4WithVrf PASSED [ 57%]
test_nhg.py::TestNextHopGroup::test_route_nhg PASSED                     [ 58%]
test_pfc.py::TestPfc::test_PfcAsymmetric PASSED                          [ 58%]
test_policer.py::TestPolicer::test_PolicerBasic PASSED                   [ 58%]
test_port.py::TestPort::test_PortMtu PASSED                              [ 59%]
test_port.py::TestPort::test_PortNotification PASSED                     [ 59%]
test_port.py::TestPort::test_PortFec PASSED                              [ 60%]
test_port.py::TestPort::test_PortPreemp PASSED                           [ 60%]
test_port.py::TestPort::test_PortIdriver PASSED                          [ 60%]
test_port.py::TestPort::test_PortIpredriver PASSED                       [ 61%]
test_port_an.py::TestPortAutoNeg::test_PortAutoNegCold PASSED            [ 61%]
test_port_an.py::TestPortAutoNeg::test_PortAutoNegWarm FAILED            [ 62%]
test_port_buffer_rel.py::TestPortBuffer::test_PortsAreUpAfterBuffers PASSED [ 62%]
test_port_config.py::TestPortConfig::test_port_hw_lane PASSED            [ 62%]
test_port_config.py::TestPortConfig::test_port_breakout PASSED           [ 63%]
test_port_dpb.py::TestPortDPB::test_port_breakout_one FAILED             [ 63%]
test_port_dpb.py::TestPortDPB::test_port_breakout_multiple FAILED        [ 64%]
test_port_dpb.py::TestPortDPB::test_port_breakout_all FAILED             [ 64%]
test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list PASSED [ 64%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED [ 65%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports FAILED [ 65%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables SKIPPED [ 66%]
test_port_dpb_system.py::TestPortDPBSystem::test_port_breakout_one ERROR [ 66%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency ERROR            [ 66%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan ERROR     [ 67%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_multiple_vlan ERROR [ 67%]
test_port_mac_learn.py::TestPortMacLearn::test_PortMacLearnMode PASSED   [ 68%]
test_port_mac_learn.py::TestPortMacLearn::test_PortchannelMacLearnMode PASSED [ 68%]
test_portchannel.py::TestPortchannel::test_Portchannel PASSED            [ 68%]
test_portchannel.py::TestPortchannel::test_Portchannel_oper_down PASSED  [ 69%]
test_qos_map.py::TestDot1p::test_dot1p_cfg PASSED                        [ 69%]
test_qos_map.py::TestDot1p::test_port_dot1p PASSED                       [ 70%]
test_route.py::TestRoute::test_RouteAddRemoveIpv4Route FAILED            [ 70%]
test_route.py::TestRoute::test_RouteAddRemoveIpv6Route FAILED            [ 70%]
test_route.py::TestRoute::test_RouteAddRemoveIpv4RouteWithVrf FAILED     [ 71%]
test_route.py::TestRoute::test_RouteAddRemoveIpv6RouteWithVrf FAILED     [ 71%]
test_route.py::TestRoute::test_RouteAndNexthopInDifferentVrf FAILED      [ 72%]
test_setro.py::TestSetRo::test_SetReadOnlyAttribute PASSED               [ 72%]
test_sflow.py::TestSflow::test_defaultGlobal PASSED                      [ 72%]
test_sflow.py::TestSflow::test_globalAll PASSED                          [ 73%]
test_sflow.py::TestSflow::test_InterfaceSet PASSED                       [ 73%]
test_sflow.py::TestSflow::test_defaultRate PASSED                        [ 74%]
test_sflow.py::TestSflow::test_ConfigDel PASSED                          [ 74%]
test_sflow.py::TestSflow::test_Teardown PASSED                           [ 75%]
test_speed.py::TestSpeedSet::test_SpeedAndBufferSet FAILED               [ 75%]
test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_creation PASSED [ 75%]
test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_add_ip_addrs PASSED [ 76%]
test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_admin_status_change PASSED [ 76%]
test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_remove_ip_addrs PASSED [ 77%]
test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_removal PASSED [ 77%]
test_switch.py::TestSwitch::test_switch_attribute PASSED                 [ 77%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v4 PASSED              [ 78%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v6 PASSED              [ 78%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v4 PASSED      [ 79%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v6 PASSED      [ 79%]
test_vlan.py::TestVlan::test_VlanAddRemove PASSED                        [ 79%]
test_vlan.py::TestVlan::test_MultipleVlan PASSED                         [ 80%]
test_vlan.py::TestVlan::test_VlanIncrementalConfig PASSED                [ 80%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input0-0] PASSED [ 81%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input1-0] PASSED [ 81%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input2-0] PASSED [ 81%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input3-1] PASSED [ 82%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input0-0] PASSED [ 82%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input1-0] PASSED [ 83%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input2-0] PASSED [ 83%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input3-1] PASSED [ 83%]
test_vlan.py::TestVlan::test_AddPortChannelToVlan PASSED                 [ 84%]
test_vlan.py::TestVlan::test_AddVlanMemberWithNonExistVlan PASSED        [ 84%]
test_vlan.py::TestVlan::test_RemoveNonexistentVlan PASSED                [ 85%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input0-expected0] PASSED [ 85%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input1-expected1] PASSED [ 85%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input2-expected2] PASSED [ 86%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input3-expected3] PASSED [ 86%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input4-expected4] PASSED [ 87%]
test_vlan.py::TestVlan::test_AddMaxVlan SKIPPED                          [ 87%]
test_vlan.py::TestVlan::test_RemoveVlanWithRouterInterface PASSED        [ 87%]
test_vlan.py::TestVlan::test_VlanDbData PASSED                           [ 88%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input0-expected0] PASSED [ 88%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input1-expected1] PASSED [ 89%]
test_vlan.py::TestVlan::test_VlanMemberDbData[test_input2-expected2] PASSED [ 89%]

test_vrf.py::TestVrf::test_VRFMgr_Comprehensive PASSED                   [ 93%]
test_vrf.py::TestVrf::test_VRFMgr PASSED                                 [ 94%]
test_vrf.py::TestVrf::test_VRFMgr_Update PASSED                          [ 94%]
test_vrf.py::TestVrf::test_VRFMgr_Capacity PASSED                        [ 95%]
test_vxlan_tunnel.py::TestVxlan::test_vxlan_term_orch PASSED             [ 95%]

test_watermark.py::TestWatermark::test_telemetry_period PASSED           [ 99%]
test_watermark.py::TestWatermark::test_lua_plugins SKIPPED               [ 99%]
test_watermark.py::TestWatermark::test_clear SKIPPED                     [100%]
```