### PR TITLE
Handle port deletion while updating lldp

### DIFF
--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -98,10 +98,12 @@ class LldpManager(object):
                                               True)
 
         self.pending_cmds = {}
+        self.config_port_names = set()
+        self.app_port_names = set()
 
     def is_port_up(self, port_name):
         """
-        Determine if a port is up or down by looking into the oper-status for the port in 
+        Determine if a port is up or down by looking into the oper-status for the port in
         PORT TABLE in the Application DB
         """
         # Retrieve all entires for this port from the Port table
@@ -141,8 +143,8 @@ class LldpManager(object):
             if not port_alias:
                 log_info("Unable to retrieve port alias for port '{}'. Using port name instead.".format(port_name))
                 port_alias = port_name
-            
-            # Get the port description. If None or empty string, we'll skip this configuration 
+
+            # Get the port description. If None or empty string, we'll skip this configuration
             port_desc = port_table_dict.get("description")
 
         else:
@@ -208,32 +210,43 @@ class LldpManager(object):
         sel.addSelectable(sst_appdb)
 
         # Listen for changes to the PORT table in the CONFIG_DB and APP_DB
+        # Only when port is present in both DBs and the operation status is UP
+        # we are going to configure it in lldp
         while True:
             (state, c) = sel.select(SELECT_TIMEOUT_MS)
 
             if state == swsscommon.Select.OBJECT:
+
+                # handle alias or description changes, by listening to
+                # changes in config DB
                 (key, op, fvp) = sst_confdb.pop()
-                if fvp:
-                    fvp_dict = dict(fvp)
-
-                    # handle config change
-                    if (fvp_dict.has_key("alias") or fvp_dict.has_key("description")) and (op in ["SET", "DEL"]):
-                        if self.is_port_up(key):
-                            self.generate_pending_lldp_config_cmd_for_port(key)
-                        else:
-                            self.pending_cmds.pop(key, None)
-
-                (key, op, fvp) = sst_appdb.pop()
-                if (key != "PortInitDone") and (key != "PortConfigDone"):
-                    if fvp:
+                if op == "DEL":
+                    self.config_port_names.discard(key)
+                    self.pending_cmds.pop(key, None)
+                elif op == "SET":
+                    self.config_port_names.add(key)
+                    if fvp and key in self.app_port_names:
                         fvp_dict = dict(fvp)
 
-                        # handle port status change
-                        if fvp_dict.has_key("oper_status"):
-                            if "up" in fvp_dict.get("oper_status"):
-                                self.generate_pending_lldp_config_cmd_for_port(key)
-                            else:
-                                self.pending_cmds.pop(key, None)
+                        if (fvp_dict.has_key("alias") or fvp_dict.has_key("description")) and (self.is_port_up(key)):
+                            self.generate_pending_lldp_config_cmd_for_port(key)
+
+                # handle port status change, by listening to
+                # changes in APP DB
+                (key, op, fvp) = sst_appdb.pop()
+                if (key != "PortInitDone") and (key != "PortConfigDone"):
+                    if op == "DEL":
+                        self.app_port_names.discard(key)
+                        self.pending_cmds.pop(key, None)
+                    elif op == "SET":
+                        self.app_port_names.add(key)
+                        if fvp and key in self.config_port_names:
+                            fvp_dict = dict(fvp)
+
+                            # handle port status change
+                            if fvp_dict.has_key("oper_status"):
+                                if "up" in fvp_dict.get("oper_status"):
+                                    self.generate_pending_lldp_config_cmd_for_port(key)
 
             # Process all pending commands
             self.process_pending_cmds()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Handled port deletion in lldpmgrd.

**- How I did it**
During dynamic port breakoput, we delete and add a port. When we delete a port, the port may NOT be present in one or both DBs (CFG and APP).

The goal is to configure the lldp when the port is present in both DBs and it has at-least alias or description set and the port is in oper_status UP.

**- How to verify it**
By running DPB command and checking the syslog messages

Before fix following error messages were seen in syslog:
```
ERR lldp#lldpmgrd: Port 'Ethernet1' not found in PORT table in Config DB. Using port name instead of port alias.
Mar 9 20:51:35.299500 lnos-x1-a-asw01 ERR lldp#python: :- pops: Failed to get content for table key PORT_TABLE:Ethernet1
Mar 9 20:51:35.301245 lnos-x1-a-asw01 ERR lldp#python: :- pops: Failed to get content for table key PORT_TABLE:Ethernet3
Mar 9 20:51:58.429793 lnos-x1-a-asw01 ERR lldp#lldpmgrd: Port 'Ethernet1' not found in PORT_TABLE table in App DB
Mar 9 20:51:58.441543 lnos-x1-a-asw01 ERR lldp#lldpmgrd: Port 'Ethernet2' not found in PORT_TABLE table in App DB
Mar 9 20:51:58.447253 lnos-x1-a-asw01 ERR lldp#lldpmgrd: Port 'Ethernet3' not found in PORT_TABLE table in App DB
```

After fix the error messages were NOT seen.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
