### PR TITLE
[sonic-yang-models]: Add default values in leaf-lists of ports in son…

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-acl.yang
+++ b/src/sonic-yang-models/yang-models/sonic-acl.yang
@@ -267,7 +267,7 @@ module sonic-acl {
 				}
 
 				leaf-list ports {
-                    /* union of leafref is allowed in YANG 1.1 */
+					/* union of leafref is allowed in YANG 1.1 */
 					type union {
 						type leafref {
 							path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
@@ -275,7 +275,15 @@ module sonic-acl {
 						type leafref {
 							path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:portchannel_name;
 						}
+						type string {
+							pattern "";
+						}
 					}
+					/* Today in SONiC, we do not delete the list once
+					 * created, instead we set to empty list. Due to that
+					 * below default values are needed.
+					 */
+					default "";
 				}
 			}
 			/* end of ACL_TABLE_LIST */

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -60,9 +60,19 @@ module sonic-portchannel {
 
 				leaf-list members {
 					/* leaf-list members are unique by default */
-					type leafref {
-						path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+					type union {
+						type leafref {
+							path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+						}
+						type string {
+							pattern "";
+						}
 					}
+					/* Today in SONiC, we do not delete the list once
+					 * created, instead we set to empty list. Due to that
+					 * below default values are needed.
+					 */
+					default "";
 				}
 
 				leaf min_links {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -161,14 +161,6 @@ module sonic-vlan {
 				leaf admin_status {
 					type head:admin_status;
 				}
-
-				leaf-list members {
-					/* leaf-list members are unique by default */
-
-					type leafref {
-						path "/port:sonic-port/port:PORT/port:PORT_LIST/port:port_name";
-					}
-				}
 			}
 			/* end of VLAN_LIST */
 		}


### PR DESCRIPTION
…ic-acl and sonic-portchannel.

Changes:
-- Add default values in leaf-lists of ports in sonic-acl
-- Add default values in leaf-lists of ports in sonic-portchannel
-- Remove members from sonic-vlan VLAN table. Note this will force Network Operations
   team to change the config.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changes:
-- Add default values in leaf-lists of ports in sonic-acl
-- Add default values in leaf-lists of ports in sonic-portchannel
-- Remove members from sonic-vlan VLAN table. Note this will force Network Operations
   team to change the config.

**- How I did it**
Added String Type and DEfault value in YANG.

**- How to verify it**
```
Default value leaf-list testing:


============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 93.69 seconds ====================
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ cat test_port_dpb_system.py | grep -A 4 -B 4 Uncomment

        # Verify port is removed from ACL table
        self.dvs_acl.verify_acl_table_count(1)

        #TBD: Uncomment this, or explain why Ethernet0 is being added back to ACL table
        # Also, string "None" is being added as port to ACL port list after the breakout
        self.dvs_acl.verify_acl_group_num(0)

        # Verify child ports are created.
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --dvsname=vs-jk test_port_dpb_system.py -k test_port_breakout_with_acl --junitxml=report.xml | tee out
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.6.0, pluggy-0.6.0
rootdir: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 2 items

test_port_dpb_system.py .                                                [100%]

 generated xml file: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests/report.xml
============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 94.25 seconds ====================
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
