### PR TITLE
CLS Silverstone: enable the init sequence for all of the QSFPDD CMIS4…

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/silverstone/modules/switchboard.c
+++ b/platform/broadcom/sonic-platform-modules-cel/silverstone/modules/switchboard.c
@@ -1431,7 +1431,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         goto Done;
     }
 
-#if 1 /* 100 kHz */
+#if 0 /* 100 kHz */
     iowrite8(portid | 0x40, pci_bar + REG_ID0);
 #else
     iowrite8(portid, pci_bar + REG_ID0);

--- a/platform/broadcom/sonic-platform-modules-cel/silverstone/modules/switchboard.c
+++ b/platform/broadcom/sonic-platform-modules-cel/silverstone/modules/switchboard.c
@@ -1431,7 +1431,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         goto Done;
     }
 
-#if 0 /* 100 kHz */
+#if 1 /* 100 kHz */
     iowrite8(portid | 0x40, pci_bar + REG_ID0);
 #else
     iowrite8(portid, pci_bar + REG_ID0);


### PR DESCRIPTION
… modules

Signed-off-by: Dante Su <dante.su@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Enable the initialization sequence for all of the QSFPDD CMIS4 modules, which used to be limited to InnoLight only.
2. Stop issuing software reset to the QSFPDD DACs even though its module state is not ModuleReady for 3+ seconds.
3. Lower the clock rate of FPGA-I2C to have the best transceiver compatibility.

**- How I did it**
See What I did

**- How to verify it**
1. Have both InnoLight and Eoptolink CMIS4 modules attached to the DUT
2. Issue 'show interfaces transceiver eeprom' to verify if their application selection is '2'
3. Intentionally disable anyone of the 4 links of the transceiver, and make sure the other 3 links are still UP

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
